### PR TITLE
fix for reporting vulnerabilities with `wp vuln core-status --nagios`

### DIFF
--- a/wp-vulnerability-scanner.php
+++ b/wp-vulnerability-scanner.php
@@ -845,7 +845,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				}
 			}
 			
-			if( empty( $pl_list ) && empty( $th_list ) ) {
+			if( empty( $wp_list ) && empty( $pl_list ) && empty( $th_list ) ) {
 				WP_CLI::line( 'OK - no vulnerabilities found' );
 				exit(0);
 			} else {


### PR DESCRIPTION
It looks like running `wp vuln core-status --nagios` currently *always* reports `OK - no vulnerabilities found`