### PR TITLE
Make valid json when using `wp vuln status --format=json`

### DIFF
--- a/wp-vulnerability-scanner.php
+++ b/wp-vulnerability-scanner.php
@@ -97,7 +97,18 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		if( $this->nagios_op ) {
 			$this->_do_nagios_op( array( 'wordpress', 'plugin', 'theme' ) );
 		}
-		
+
+		if ( 'json' == $this->{ $assoc_args }['format'] ) {
+			echo '{"core":';
+			$this->_do_wordpress();
+			echo ',"plugins":';
+			$this->_do_plugins();
+			echo ',"themes":';
+			$this->_do_themes();
+			echo '}';
+			exit( 0 );
+		}
+
 		WP_CLI::log( WP_CLI::colorize( '%GWordPress ' . $wp_version . ' %n' ) );
 		$this->_do_wordpress();
 		
@@ -412,7 +423,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				// it would be nice to show this, but we'd need to rewrite the unit test
 				//              $update_list = implode( ' ', $update_list );
 				//              WP_CLI::log( "Run `wp $singular_type update $update_list`" );
-			} else {
+			} elseif( ( isset( $this->{$assoc_args}['format'] ) && 'json' != $this->$assoc_args['format'] ) ) {
 				WP_CLI::log( 'Nothing to update' );
 			}
 		} elseif ( $update_list ) {


### PR DESCRIPTION
This command outputs multiple JSON lists, yet it's reasonable to expect a single output in JSON; what's more you have to use --quiet to avoid text string being output too.
This outputs a single valid JSON array that merges all 3 outputs.