### PR TITLE
Normalise text output

### DIFF
--- a/wp-vulnerability-scanner.php
+++ b/wp-vulnerability-scanner.php
@@ -654,7 +654,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 		if ( 404 == $code ) {
 			$report[] = array(
-				'title' => "No reported vulnerabilities for $slug",
+				'title' => "No vulnerabilities reported for $slug",
 				'fix'   => 'n/a',
 			);
 		} else {


### PR DESCRIPTION
Settle on "No vulnerabilities reported" everywhere instead of mixed in with "No reported vulnerabilities".