### PR TITLE
Use slug to reference plugin/theme name

### DIFF
--- a/wp-vulnerability-scanner.php
+++ b/wp-vulnerability-scanner.php
@@ -675,8 +675,8 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 			$vulnerabilities = array();
 
-			if ( isset( $vulndb->$singular_type ) && isset( $vulndb->$singular_type->vulnerabilities ) ) {
-				$vulnerabilities = $vulndb->$singular_type->vulnerabilities;
+			if ( isset( $vulndb->$slug ) && isset( $vulndb->$slug->vulnerabilities ) ) {
+				$vulnerabilities = $vulndb->$slug->vulnerabilities;
 			}
 
 			if ( is_array( $vulnerabilities ) && ! empty( $vulnerabilities ) ) {


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes #38 

It looks like `$singular_type` was not meant to be used but `$slug` to reference the plugin/theme slug to retrieve the vulnerabilities from the JSON here: 

https://github.com/10up/wp-vulnerability-scanner/blob/master/wp-vulnerability-scanner.php#L667

`$singular_type` seems to reference if we are referencing either a plugin or a theme, does not seem to relate to the slug. 

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Reproduced the scenario described on #38 and now it is showing the vulnerability accordingly

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
