### PR TITLE
Feature/add introduced in field

### DIFF
--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -570,7 +570,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 							$report[] = array(
 								'title'         => $vuln->title,
 								'fix'           => 'Not fixed',
-								'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+								'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
 								'action'        => 'watch',
 							);
 
@@ -580,7 +580,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 							$report[] = array(
 								'title'         => $vuln->title,
 								'fix'           => "Fixed in {$vuln->fixed_in}",
-								'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+								'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
 								'action'        => 'update',
 							);
 
@@ -721,7 +721,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 						$report[] = array(
 							'title'         => $vuln->title,
 							'fix'           => 'Not fixed',
-							'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+							'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
 							'action'        => 'watch',
 						);
 
@@ -731,7 +731,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 						$report[] = array(
 							'title'         => $vuln->title,
 							'fix'           => "Fixed in {$vuln->fixed_in}",
-							'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+							'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
 							'action'        => 'update',
 						);
 

--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -361,9 +361,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'name',
 				'installed version',
 				'status',
+				'introduced in',
 				'fix',
 			), $plural_type );
-			$formatter->display_items( $display );
+			// Add second array parameter to indicate the position of the column having a maybe colorized item.
+			$formatter->display_items(
+				$display,
+				array(
+					true,
+					false,
+					false,
+					false,
+					false,
+				)
+			);
 		} elseif ( $update_list ) {
 			WP_CLI::log( implode( ' ', $update_list ) );
 			die;
@@ -413,9 +424,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'name',
 				'installed version',
 				'status',
+				'introduced in',
 				'fix',
 			), $plural_type );
-			$formatter->display_items( $display );
+			// Add second array parameter to indicate the position of the column having a maybe colorized item.
+			$formatter->display_items(
+				$display,
+				array(
+					true,
+					false,
+					false,
+					false,
+					false,
+				)
+			);
 
 			// if plugins need updating, do or tell the user
 			if ( $update_list ) {
@@ -519,7 +541,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		if ( 404 === $code ) {
 			$report[] = array(
 				'title' => "Error generating report for WordPress " . $wp_version,
-				'fix'   => 'n/a',
 			);
 		} else {
 
@@ -530,12 +551,10 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				if ( isset( $vulndb->error ) ) {
 					$report[] = array(
 						'title' => $vulndb->error,
-						'fix'   => 'n/a',
 					);
 				} else {
 					$report[] = array(
 						'title' => "NVF Error generating report for WordPress " . $wp_version,
-						'fix'   => 'n/a',
 					);
 				}
 			} else {
@@ -549,18 +568,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 						if ( ! isset( $vuln->fixed_in ) ) {
 
 							$report[] = array(
-								'title'  => $vuln->title,
-								'fix'    => 'Not fixed',
-								'action' => 'watch',
+								'title'         => $vuln->title,
+								'fix'           => 'Not fixed',
+								'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+								'action'        => 'watch',
 							);
 
 							// vuln version, fix available
 						} elseif ( version_compare( $wp_version, $vuln->fixed_in, '<' ) ) {
 
 							$report[] = array(
-								'title'  => $vuln->title,
-								'fix'    => "Fixed in {$vuln->fixed_in}",
-								'action' => 'update',
+								'title'         => $vuln->title,
+								'fix'           => "Fixed in {$vuln->fixed_in}",
+								'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+								'action'        => 'update',
 							);
 
 							// if installed plugin version is greater than a fixed version,
@@ -578,7 +599,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				if ( $total <= 0 ) {
 					$report[] = array(
 						'title' => "No vulnerabilities reported for this version of WordPress",
-						'fix'   => 'n/a',
 					);
 				}
 			}
@@ -587,19 +607,25 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$data = array();
 
 		foreach ( $report as $index => $stat ) {
-			if ( ! isset( $stat['action'] ) ) {
-				$stat['action'] = '';
-			}
-
+			
+			$stat = wp_parse_args(
+				$stat,
+				array(
+					'action'        => '',
+					'fix'           => 'n/a',
+					'introduced_in' => 'n/a',
+				)
+			);
+			
 			$name = ( $table_format && 0 != $index ? '' : 'WordPress' );
 
 			if ( $table_format ) {
 				switch ( $stat['action'] ) {
 					case 'update' :
-						$name = WP_CLI::colorize( "%r$name%n" );
+						$name = \WP_CLI::colorize( "%r$name%n" );
 						break;
 					case 'watch' :
-						$name = WP_CLI::colorize( "%y$name%n" );
+						$name = \WP_CLI::colorize( "%y$name%n" );
 						break;
 					default;
 				}
@@ -612,7 +638,8 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'installed version' => $wp_version,
 				'status'            => $stat['title'],
 				'fix'               => $stat['fix'],
-				'action'            => isset( $stat['action'] ) ? $stat['action'] : '',
+				'introduced in'     => $stat['introduced_in'],
+				'action'            => $stat['action'],
 			);
 		}
 
@@ -667,7 +694,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		if ( 404 === $code ) {
 			$report[] = array(
 				'title' => "Error generating report for $slug",
-				'fix'   => 'n/a',
 			);
 		} else {
 
@@ -677,7 +703,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			if ( isset( $vulndb->error ) ) {
 				$report[] = array(
 					'title' => "Error generating report for $slug",
-					'fix'   => 'n/a',
 				);
 			}
 
@@ -694,18 +719,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					if ( ! isset( $vuln->fixed_in ) ) {
 
 						$report[] = array(
-							'title'  => $vuln->title,
-							'fix'    => 'Not fixed',
-							'action' => 'watch',
+							'title'         => $vuln->title,
+							'fix'           => 'Not fixed',
+							'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+							'action'        => 'watch',
 						);
 
 						// vuln version, fix available
 					} elseif ( version_compare( $version, $vuln->fixed_in, '<' ) ) {
 
 						$report[] = array(
-							'title'  => $vuln->title,
-							'fix'    => "Fixed in {$vuln->fixed_in}",
-							'action' => 'update',
+							'title'         => $vuln->title,
+							'fix'           => "Fixed in {$vuln->fixed_in}",
+							'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+							'action'        => 'update',
 						);
 
 						// if installed plugin version is greater than a fixed version,
@@ -723,7 +750,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			if ( $total <= 0 ) {
 				$report[] = array(
 					'title' => "No vulnerabilities reported for this version of $slug",
-					'fix'   => 'n/a',
 				);
 			}
 		}
@@ -732,10 +758,15 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 		$last_item = '';
 		foreach ( $report as $stat ) {
-			if ( ! isset( $stat['action'] ) ) {
-				$stat['action'] = '';
-			}
 
+			$stat = wp_parse_args(
+				$stat,
+				array(
+					'action'        => '',
+					'fix'           => 'n/a',
+					'introduced_in' => 'n/a',
+				)
+			);
 			$name = ( $table_format && $slug == $last_item ? '' : $slug );
 
 			if ( $table_format ) {
@@ -757,7 +788,8 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'installed version' => $version,
 				'status'            => $stat['title'],
 				'fix'               => $stat['fix'],
-				'action'            => isset( $stat['action'] ) ? $stat['action'] : '',
+				'introduced in'     => $stat['introduced_in'],
+				'action'            => $stat['action'],
 			);
 			$last_item = $slug;
 		}

--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -564,28 +564,37 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				if ( is_array( $vulnerabilities ) ) {
 					foreach ( $vulnerabilities as $k => $vuln ) {
 
+						// API has records for when was introduced ?
+						$reported_since = $this->obj_has_non_empty_prop( 'introduced_in', $vuln );
+
 						// vulnerability that hasn't been fixed :(
 						if ( ! isset( $vuln->fixed_in ) ) {
 
 							$report[] = array(
 								'title'         => $vuln->title,
 								'fix'           => 'Not fixed',
-								'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
+								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 								'action'        => 'watch',
 							);
 
-							// vuln version, fix available
-						} elseif ( version_compare( $wp_version, $vuln->fixed_in, '<' ) ) {
+							// vuln version, fix available.
+						} elseif (
+							// if no records for when it was introduced, compare against current WordPress version.
+							( ! $reported_since && version_compare( $wp_version, $vuln->fixed_in, '<' ) )
+							||
+							// if have records for when it was introduced, compare against current WordPress version.
+							( $reported_since && version_compare( $wp_version, $vuln->introduced_in, '>=' ) )
+						) {
 
 							$report[] = array(
 								'title'         => $vuln->title,
-								'fix'           => "Fixed in {$vuln->fixed_in}",
-								'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
+								'fix'           => " Fixed in {$vuln->fixed_in}",
+								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 								'action'        => 'update',
 							);
 
 							// if installed plugin version is greater than a fixed version,
-							//    unset that vuln entry, we don't need it
+							// unset that vuln entry, we don't need it.
 						} else {
 
 							// This leaves us with an array of relevant vulns
@@ -607,7 +616,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$data = array();
 
 		foreach ( $report as $index => $stat ) {
-			
+
 			$stat = wp_parse_args(
 				$stat,
 				array(
@@ -616,22 +625,22 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					'introduced_in' => 'n/a',
 				)
 			);
-			
+
 			$name = ( $table_format && 0 != $index ? '' : 'WordPress' );
 
 			if ( $table_format ) {
 				switch ( $stat['action'] ) {
-					case 'update' :
+					case 'update':
 						$name = \WP_CLI::colorize( "%r$name%n" );
 						break;
-					case 'watch' :
+					case 'watch':
 						$name = \WP_CLI::colorize( "%y$name%n" );
 						break;
 					default;
 				}
 			}
 
-			// these keys must match the column headings in the formatter (extras ok)
+			// these keys must match the column headings in the formatter (extras ok).
 			$data[] = array(
 				'name'              => $name,
 				'slug'              => 'wordpress',
@@ -715,28 +724,37 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			if ( is_array( $vulnerabilities ) && ! empty( $vulnerabilities ) ) {
 				foreach ( $vulnerabilities as $k => $vuln ) {
 
+					// API has records for when was introduced ?
+					$reported_since = $this->obj_has_non_empty_prop( 'introduced_in', $vuln );
+
 					// vulnerability that hasn't been fixed :(
 					if ( ! isset( $vuln->fixed_in ) ) {
 
 						$report[] = array(
 							'title'         => $vuln->title,
 							'fix'           => 'Not fixed',
-							'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
+							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 							'action'        => 'watch',
 						);
 
-						// vuln version, fix available
-					} elseif ( version_compare( $version, $vuln->fixed_in, '<' ) ) {
+						// vuln version, fix available.
+					} elseif (
+						// if no records for when it was introduced, compare against current WordPress version.
+						( ! $reported_since && version_compare( $version, $vuln->fixed_in, '<' ) )
+						||
+						// if have records for when it was introduced, compare against current WordPress version.
+						( $reported_since && version_compare( $version, $vuln->introduced_in, '>=' ) )
+					) {
 
 						$report[] = array(
 							'title'         => $vuln->title,
 							'fix'           => "Fixed in {$vuln->fixed_in}",
-							'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
+							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 							'action'        => 'update',
 						);
 
 						// if installed plugin version is greater than a fixed version,
-						//    unset that vuln entry, we don't need it
+						// unset that vuln entry, we don't need it.
 					} else {
 
 						// This leaves us with an array of relevant vulns
@@ -771,17 +789,17 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 			if ( $table_format ) {
 				switch ( $stat['action'] ) {
-					case 'update' :
+					case 'update':
 						$name = WP_CLI::colorize( "%r$name%n" );
 						break;
-					case 'watch' :
+					case 'watch':
 						$name = WP_CLI::colorize( "%y$name%n" );
 						break;
 					default;
 				}
 			}
 
-			// these keys must match the column headings in the formatter (extras ok)
+			// these keys must match the column headings in the formatter (extras ok).
 			$data[]    = array(
 				'name'              => $name,
 				'slug'              => $slug,
@@ -980,6 +998,17 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Helper function to check for a given property in an object
+	 *
+	 * @param string $field  Property name.
+	 * @param object $object Object having vulnerability details.
+	 * @return bool          Flag indicating the API
+	 */
+	protected function obj_has_non_empty_prop( $field, $object ) {
+		return isset( $object->{$field} ) && ! ( empty( $object->{$field} ) );
 	}
 }
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Use the new "introduced_in" API field to more accurately identify vulnerable versions

### Possible Drawbacks


### Verification Process

Run the available commands with the different formats (ids was not showing the correct format before my changes)
![image](https://user-images.githubusercontent.com/4009928/111570898-83b45b00-8784-11eb-827d-8f80ef16dac0.png)
![image](https://user-images.githubusercontent.com/4009928/111570949-a181c000-8784-11eb-8c4f-7f699f2d409b.png)
![image](https://user-images.githubusercontent.com/4009928/111571037-d4c44f00-8784-11eb-9262-d4e8155d7c73.png)
![image](https://user-images.githubusercontent.com/4009928/111571128-ff160c80-8784-11eb-9093-ee945e53fe04.png)
![image](https://user-images.githubusercontent.com/4009928/111571252-32589b80-8785-11eb-8a2b-75c6591ec08b.png)


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

https://github.com/10up/wp-vulnerability-scanner/issues/48

### Changelog Entry

Added:
- Add support for "introduced_in" WPSCAN API field.

Fixed:
- Fix: Table format columns not having the same width as table header for colorized items.

Changed:
- Improve: Use wp_parse_args()
