### PR TITLE
Fix/ids output format

### DIFF
--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -9,12 +9,11 @@
  * Author URI: http://10up.com
  * License: MIT
  */
-
 if ( ! defined( 'WP_CLI' ) ) {
 	return;
 }
 
-//API URL constant defined so we can override it if needed.
+// API URL constant defined so we can override it if needed.
 if ( ! defined( 'VULN_API_URL' ) ) {
 	define( 'VULN_API_URL', 'https://wpvulndb.com/api/v3/' );
 }
@@ -110,10 +109,8 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 		WP_CLI::log( WP_CLI::colorize( '%GWordPress ' . $wp_version . ' %n' ) );
 		$this->_do_wordpress();
-
 		WP_CLI::log( WP_CLI::colorize( '%GPlugins%n' ) );
 		$this->_do_plugins();
-
 		WP_CLI::log( WP_CLI::colorize( '%GThemes%n' ) );
 		$this->_do_themes();
 
@@ -194,14 +191,12 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$this->mail      = isset( $assoc_args['mail'] ) ? $assoc_args['mail'] : '';
 
 		$this->update_list = array();
-
-		// need a copy because it's passed by ref and destroyed in the formatter
+		// need a copy because it's passed by ref and destroyed in the formatter.
 		$this->assoc_args_plugin = $assoc_args;
 
 		if ( $this->nagios_op ) {
 			$this->_do_nagios_op( array( 'plugin' ) );
 		}
-
 		$this->_do_plugins();
 
 	}
@@ -354,9 +349,11 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$display     = $this->_check_wordpress();
 		$update_list = $this->_extract_updatable_items( $display );
 
+		$display_format = isset( $this->$assoc_args['format'] ) && ! empty( $this->$assoc_args['format'] ) ? $this->$assoc_args['format'] : 'table';
+		$display        = $this->format_data_for_return( $display_format, $display );
+
 		// Pretty print
 		if ( ! $this->porcelain ) {
-
 			$formatter = new \WP_CLI\Formatter( $this->$assoc_args, array(
 				'name',
 				'installed version',
@@ -375,6 +372,10 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					false,
 				)
 			);
+			// Improve readeability: force new line.
+			if ( 'ids' === $display_format ) {
+				WP_CLI::log( '' );
+			}
 		} elseif ( $update_list ) {
 			WP_CLI::log( implode( ' ', $update_list ) );
 			die;
@@ -417,7 +418,10 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$display     = $this->_check_thing( $singular_type );
 		$update_list = $this->_extract_updatable_items( $display );
 
-		// Pretty print
+		$display_format = isset( $this->$assoc_args['format'] ) && ! empty( $this->$assoc_args['format'] ) ? $this->$assoc_args['format'] : 'table';
+		$display        = $this->format_data_for_return( $display_format, $display );
+
+		// Pretty print.
 		if ( ! $this->porcelain ) {
 
 			$formatter = new \WP_CLI\Formatter( $this->$assoc_args, array(
@@ -439,13 +443,18 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				)
 			);
 
-			// if plugins need updating, do or tell the user
+			// if plugins need updating, do or tell the user.
 			if ( $update_list ) {
 				// it would be nice to show this, but we'd need to rewrite the unit test
 				//              $update_list = implode( ' ', $update_list );
 				//              WP_CLI::log( "Run `wp $singular_type update $update_list`" );
 			} else {
 				WP_CLI::log( 'Nothing to update' );
+			}
+
+			// Improve readeability: force new line.
+			if ( 'ids' === $display_format ) {
+				WP_CLI::log( '' );
 			}
 		} elseif ( $update_list ) {
 			WP_CLI::log( implode( ' ', $update_list ) );
@@ -566,11 +575,11 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 						// API has records for when was introduced ?
 						$reported_since = $this->obj_has_non_empty_prop( 'introduced_in', $vuln );
-
 						// vulnerability that hasn't been fixed :(
 						if ( ! isset( $vuln->fixed_in ) ) {
 
 							$report[] = array(
+								'id'            => $vuln->id,
 								'title'         => $vuln->title,
 								'fix'           => 'Not fixed',
 								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
@@ -587,6 +596,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 						) {
 
 							$report[] = array(
+								'id'            => $vuln->id,
 								'title'         => $vuln->title,
 								'fix'           => " Fixed in {$vuln->fixed_in}",
 								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
@@ -620,6 +630,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			$stat = wp_parse_args(
 				$stat,
 				array(
+					'id'            => '',
 					'action'        => '',
 					'fix'           => 'n/a',
 					'introduced_in' => 'n/a',
@@ -645,6 +656,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'name'              => $name,
 				'slug'              => 'wordpress',
 				'installed version' => $wp_version,
+				'id'                => $stat['id'],
 				'status'            => $stat['title'],
 				'fix'               => $stat['fix'],
 				'introduced in'     => $stat['introduced_in'],
@@ -723,7 +735,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 			if ( is_array( $vulnerabilities ) && ! empty( $vulnerabilities ) ) {
 				foreach ( $vulnerabilities as $k => $vuln ) {
-
 					// API has records for when was introduced ?
 					$reported_since = $this->obj_has_non_empty_prop( 'introduced_in', $vuln );
 
@@ -731,6 +742,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					if ( ! isset( $vuln->fixed_in ) ) {
 
 						$report[] = array(
+							'id'            => $vuln->id,
 							'title'         => $vuln->title,
 							'fix'           => 'Not fixed',
 							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
@@ -747,6 +759,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					) {
 
 						$report[] = array(
+							'id'            => $vuln->id,
 							'title'         => $vuln->title,
 							'fix'           => "Fixed in {$vuln->fixed_in}",
 							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
@@ -780,6 +793,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			$stat = wp_parse_args(
 				$stat,
 				array(
+					'id'            => '',
 					'action'        => '',
 					'fix'           => 'n/a',
 					'introduced_in' => 'n/a',
@@ -804,6 +818,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'name'              => $name,
 				'slug'              => $slug,
 				'installed version' => $version,
+				'id'                => $stat['id'],
 				'status'            => $stat['title'],
 				'fix'               => $stat['fix'],
 				'introduced in'     => $stat['introduced_in'],
@@ -1009,6 +1024,26 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 */
 	protected function obj_has_non_empty_prop( $field, $object ) {
 		return isset( $object->{$field} ) && ! ( empty( $object->{$field} ) );
+	}
+
+	/**
+	 * Format data before output based on --format parameter passed to command.
+	 *
+	 * @param string $output_format  One of table, csv, json, count, ids, yaml.
+	 * @param array  $data           Array having report details.
+	 * @return array $applied_format Array for correct output.
+	 */
+	protected function format_data_for_return( $output_format, $data ) {
+
+		switch ( $output_format ) {
+			case 'ids':
+				$applied_format = array_filter( wp_list_pluck( $data, 'id' ) );
+				break;
+			default:
+				$applied_format = $data;
+		}
+
+		return $applied_format;
 	}
 }
 

--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -570,7 +570,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 							$report[] = array(
 								'title'         => $vuln->title,
 								'fix'           => 'Not fixed',
-								'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+								'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
 								'action'        => 'watch',
 							);
 
@@ -580,7 +580,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 							$report[] = array(
 								'title'         => $vuln->title,
 								'fix'           => "Fixed in {$vuln->fixed_in}",
-								'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+								'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
 								'action'        => 'update',
 							);
 
@@ -721,7 +721,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 						$report[] = array(
 							'title'         => $vuln->title,
 							'fix'           => 'Not fixed',
-							'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+							'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
 							'action'        => 'watch',
 						);
 
@@ -731,7 +731,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 						$report[] = array(
 							'title'         => $vuln->title,
 							'fix'           => "Fixed in {$vuln->fixed_in}",
-							'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+							'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
 							'action'        => 'update',
 						);
 

--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -361,9 +361,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'name',
 				'installed version',
 				'status',
+				'introduced in',
 				'fix',
 			), $plural_type );
-			$formatter->display_items( $display );
+			// Add second array parameter to indicate the position of the column having a maybe colorized item.
+			$formatter->display_items(
+				$display,
+				array(
+					true,
+					false,
+					false,
+					false,
+					false,
+				)
+			);
 		} elseif ( $update_list ) {
 			WP_CLI::log( implode( ' ', $update_list ) );
 			die;
@@ -413,9 +424,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'name',
 				'installed version',
 				'status',
+				'introduced in',
 				'fix',
 			), $plural_type );
-			$formatter->display_items( $display );
+			// Add second array parameter to indicate the position of the column having a maybe colorized item.
+			$formatter->display_items(
+				$display,
+				array(
+					true,
+					false,
+					false,
+					false,
+					false,
+				)
+			);
 
 			// if plugins need updating, do or tell the user
 			if ( $update_list ) {
@@ -519,7 +541,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		if ( 404 === $code ) {
 			$report[] = array(
 				'title' => "Error generating report for WordPress " . $wp_version,
-				'fix'   => 'n/a',
 			);
 		} else {
 
@@ -530,12 +551,10 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				if ( isset( $vulndb->error ) ) {
 					$report[] = array(
 						'title' => $vulndb->error,
-						'fix'   => 'n/a',
 					);
 				} else {
 					$report[] = array(
 						'title' => "NVF Error generating report for WordPress " . $wp_version,
-						'fix'   => 'n/a',
 					);
 				}
 			} else {
@@ -549,18 +568,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 						if ( ! isset( $vuln->fixed_in ) ) {
 
 							$report[] = array(
-								'title'  => $vuln->title,
-								'fix'    => 'Not fixed',
-								'action' => 'watch',
+								'title'         => $vuln->title,
+								'fix'           => 'Not fixed',
+								'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+								'action'        => 'watch',
 							);
 
 							// vuln version, fix available
 						} elseif ( version_compare( $wp_version, $vuln->fixed_in, '<' ) ) {
 
 							$report[] = array(
-								'title'  => $vuln->title,
-								'fix'    => "Fixed in {$vuln->fixed_in}",
-								'action' => 'update',
+								'title'         => $vuln->title,
+								'fix'           => "Fixed in {$vuln->fixed_in}",
+								'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+								'action'        => 'update',
 							);
 
 							// if installed plugin version is greater than a fixed version,
@@ -578,7 +599,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				if ( $total <= 0 ) {
 					$report[] = array(
 						'title' => "No vulnerabilities reported for this version of WordPress",
-						'fix'   => 'n/a',
 					);
 				}
 			}
@@ -587,19 +607,25 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$data = array();
 
 		foreach ( $report as $index => $stat ) {
-			if ( ! isset( $stat['action'] ) ) {
-				$stat['action'] = '';
-			}
-
+			
+			$stat = wp_parse_args(
+				$stat,
+				array(
+					'action'        => '',
+					'fix'           => 'n/a',
+					'introduced_in' => 'n/a',
+				)
+			);
+			
 			$name = ( $table_format && 0 != $index ? '' : 'WordPress' );
 
 			if ( $table_format ) {
 				switch ( $stat['action'] ) {
 					case 'update' :
-						$name = WP_CLI::colorize( "%r$name%n" );
+						$name = \WP_CLI::colorize( "%r$name%n" );
 						break;
 					case 'watch' :
-						$name = WP_CLI::colorize( "%y$name%n" );
+						$name = \WP_CLI::colorize( "%y$name%n" );
 						break;
 					default;
 				}
@@ -612,7 +638,8 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'installed version' => $wp_version,
 				'status'            => $stat['title'],
 				'fix'               => $stat['fix'],
-				'action'            => isset( $stat['action'] ) ? $stat['action'] : '',
+				'introduced in'     => $stat['introduced_in'],
+				'action'            => $stat['action'],
 			);
 		}
 
@@ -667,7 +694,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		if ( 404 === $code ) {
 			$report[] = array(
 				'title' => "Error generating report for $slug",
-				'fix'   => 'n/a',
 			);
 		} else {
 
@@ -677,7 +703,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			if ( isset( $vulndb->error ) ) {
 				$report[] = array(
 					'title' => "Error generating report for $slug",
-					'fix'   => 'n/a',
 				);
 			}
 
@@ -694,18 +719,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					if ( ! isset( $vuln->fixed_in ) ) {
 
 						$report[] = array(
-							'title'  => $vuln->title,
-							'fix'    => 'Not fixed',
-							'action' => 'watch',
+							'title'         => $vuln->title,
+							'fix'           => 'Not fixed',
+							'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+							'action'        => 'watch',
 						);
 
 						// vuln version, fix available
 					} elseif ( version_compare( $version, $vuln->fixed_in, '<' ) ) {
 
 						$report[] = array(
-							'title'  => $vuln->title,
-							'fix'    => "Fixed in {$vuln->fixed_in}",
-							'action' => 'update',
+							'title'         => $vuln->title,
+							'fix'           => "Fixed in {$vuln->fixed_in}",
+							'introduced_in' => isset( $vuln->introduced_in ) ? $vuln->introduced_in : 'n/a',
+							'action'        => 'update',
 						);
 
 						// if installed plugin version is greater than a fixed version,
@@ -723,7 +750,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			if ( $total <= 0 ) {
 				$report[] = array(
 					'title' => "No vulnerabilities reported for this version of $slug",
-					'fix'   => 'n/a',
 				);
 			}
 		}
@@ -732,10 +758,15 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 		$last_item = '';
 		foreach ( $report as $stat ) {
-			if ( ! isset( $stat['action'] ) ) {
-				$stat['action'] = '';
-			}
 
+			$stat = wp_parse_args(
+				$stat,
+				array(
+					'action'        => '',
+					'fix'           => 'n/a',
+					'introduced_in' => 'n/a',
+				)
+			);
 			$name = ( $table_format && $slug == $last_item ? '' : $slug );
 
 			if ( $table_format ) {
@@ -757,7 +788,8 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'installed version' => $version,
 				'status'            => $stat['title'],
 				'fix'               => $stat['fix'],
-				'action'            => isset( $stat['action'] ) ? $stat['action'] : '',
+				'introduced in'     => $stat['introduced_in'],
+				'action'            => $stat['action'],
 			);
 			$last_item = $slug;
 		}

--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -564,28 +564,37 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				if ( is_array( $vulnerabilities ) ) {
 					foreach ( $vulnerabilities as $k => $vuln ) {
 
+						// API has records for when was introduced ?
+						$reported_since = $this->obj_has_non_empty_prop( 'introduced_in', $vuln );
+
 						// vulnerability that hasn't been fixed :(
 						if ( ! isset( $vuln->fixed_in ) ) {
 
 							$report[] = array(
 								'title'         => $vuln->title,
 								'fix'           => 'Not fixed',
-								'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
+								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 								'action'        => 'watch',
 							);
 
-							// vuln version, fix available
-						} elseif ( version_compare( $wp_version, $vuln->fixed_in, '<' ) ) {
+							// vuln version, fix available.
+						} elseif (
+							// if no records for when it was introduced, compare against current WordPress version.
+							( ! $reported_since && version_compare( $wp_version, $vuln->fixed_in, '<' ) )
+							||
+							// if have records for when it was introduced, compare against current WordPress version.
+							( $reported_since && version_compare( $wp_version, $vuln->introduced_in, '>=' ) )
+						) {
 
 							$report[] = array(
 								'title'         => $vuln->title,
-								'fix'           => "Fixed in {$vuln->fixed_in}",
-								'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
+								'fix'           => " Fixed in {$vuln->fixed_in}",
+								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 								'action'        => 'update',
 							);
 
 							// if installed plugin version is greater than a fixed version,
-							//    unset that vuln entry, we don't need it
+							// unset that vuln entry, we don't need it.
 						} else {
 
 							// This leaves us with an array of relevant vulns
@@ -607,7 +616,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$data = array();
 
 		foreach ( $report as $index => $stat ) {
-			
+
 			$stat = wp_parse_args(
 				$stat,
 				array(
@@ -616,22 +625,22 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					'introduced_in' => 'n/a',
 				)
 			);
-			
+
 			$name = ( $table_format && 0 != $index ? '' : 'WordPress' );
 
 			if ( $table_format ) {
 				switch ( $stat['action'] ) {
-					case 'update' :
+					case 'update':
 						$name = \WP_CLI::colorize( "%r$name%n" );
 						break;
-					case 'watch' :
+					case 'watch':
 						$name = \WP_CLI::colorize( "%y$name%n" );
 						break;
 					default;
 				}
 			}
 
-			// these keys must match the column headings in the formatter (extras ok)
+			// these keys must match the column headings in the formatter (extras ok).
 			$data[] = array(
 				'name'              => $name,
 				'slug'              => 'wordpress',
@@ -715,28 +724,37 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			if ( is_array( $vulnerabilities ) && ! empty( $vulnerabilities ) ) {
 				foreach ( $vulnerabilities as $k => $vuln ) {
 
+					// API has records for when was introduced ?
+					$reported_since = $this->obj_has_non_empty_prop( 'introduced_in', $vuln );
+
 					// vulnerability that hasn't been fixed :(
 					if ( ! isset( $vuln->fixed_in ) ) {
 
 						$report[] = array(
 							'title'         => $vuln->title,
 							'fix'           => 'Not fixed',
-							'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
+							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 							'action'        => 'watch',
 						);
 
-						// vuln version, fix available
-					} elseif ( version_compare( $version, $vuln->fixed_in, '<' ) ) {
+						// vuln version, fix available.
+					} elseif (
+						// if no records for when it was introduced, compare against current WordPress version.
+						( ! $reported_since && version_compare( $version, $vuln->fixed_in, '<' ) )
+						||
+						// if have records for when it was introduced, compare against current WordPress version.
+						( $reported_since && version_compare( $version, $vuln->introduced_in, '>=' ) )
+					) {
 
 						$report[] = array(
 							'title'         => $vuln->title,
 							'fix'           => "Fixed in {$vuln->fixed_in}",
-							'introduced_in' => isset( $vuln->introduced_in ) && ! ( empty( $vuln->introduced_in ) ) ? $vuln->introduced_in : 'n/a',
+							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 							'action'        => 'update',
 						);
 
 						// if installed plugin version is greater than a fixed version,
-						//    unset that vuln entry, we don't need it
+						// unset that vuln entry, we don't need it.
 					} else {
 
 						// This leaves us with an array of relevant vulns
@@ -771,17 +789,17 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 			if ( $table_format ) {
 				switch ( $stat['action'] ) {
-					case 'update' :
+					case 'update':
 						$name = WP_CLI::colorize( "%r$name%n" );
 						break;
-					case 'watch' :
+					case 'watch':
 						$name = WP_CLI::colorize( "%y$name%n" );
 						break;
 					default;
 				}
 			}
 
-			// these keys must match the column headings in the formatter (extras ok)
+			// these keys must match the column headings in the formatter (extras ok).
 			$data[]    = array(
 				'name'              => $name,
 				'slug'              => $slug,
@@ -980,6 +998,17 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Helper function to check for a given property in an object
+	 *
+	 * @param string $field  Property name.
+	 * @param object $object Object having vulnerability details.
+	 * @return bool          Flag indicating the API
+	 */
+	protected function obj_has_non_empty_prop( $field, $object ) {
+		return isset( $object->{$field} ) && ! ( empty( $object->{$field} ) );
 	}
 }
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fix output format for ids : `--format=ids`
Output now is a list of vulnerabilities ids from wpscan.com API

### Benefits
Correct output format 

### Possible Drawbacks
- 

### Verification Process

run `$ wp vuln status --format=ids`

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Issue: https://github.com/10up/wpcli-vulnerability-scanner/issues/24
Dependency: https://github.com/10up/wpcli-vulnerability-scanner/pull/50

### Changelog Entry

Fixed: 
- Output format when using `--format=ids`
Changed:
- Add vulnerability id to the report object, only used when format=ids
- Output: Force the green header on a new line when format=ids

![image](https://user-images.githubusercontent.com/4009928/112024922-6e885500-8b13-11eb-8b9f-86abfcdeec78.png)


