### PR TITLE
[WIP] Updates to formatting options

### DIFF
--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -64,6 +64,36 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	var $mail;
 
 	/**
+	 * The format type supplied via command line. Accepted values:
+	 * - table (default)
+	 * - csv
+	 * - json
+	 * - count
+	 * - ids
+	 * - yaml
+	 *
+	 * @var string The format type string.
+	 */
+	public $assoc_args_format = 'table';
+
+	/**
+	 * Current installed version of WordPress.
+	 *
+	 * @var string The verison number as a string.
+	 */
+	public $wordpress_version;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		// Prepare the value for the current installed version of WordPress.
+		$this->get_wp_version();
+	}
+
+	/**
 	 * Check plugins and themes for reported vulnerabilities.
 	 *
 	 * ## OPTIONS
@@ -102,21 +132,15 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$this->assoc_args_theme     = $assoc_args;
 		$this->assoc_args_wordpress = $assoc_args;
 
-		global $wp_version;
-
 		if ( $this->nagios_op ) {
 			$this->_do_nagios_op( array( 'wordpress', 'plugin', 'theme' ) );
 		}
 
-		WP_CLI::log( WP_CLI::colorize( '%GWordPress ' . $wp_version . ' %n' ) );
-		$this->_do_wordpress();
+		// Obtain format type value.
+		$this->assoc_args_format = strtolower( $assoc_args['format'] );
 
-		WP_CLI::log( WP_CLI::colorize( '%GPlugins%n' ) );
-		$this->_do_plugins();
-
-		WP_CLI::log( WP_CLI::colorize( '%GThemes%n' ) );
-		$this->_do_themes();
-
+		// Display status results in specified format.
+		$this->display_formatted_status_results( $this->assoc_args_format );
 	}
 
 	/**
@@ -498,11 +522,10 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 		global $wp_version;
 
-		$version  = str_replace( '.', '', $wp_version );
+		$version  = str_replace( '.', '', $this->wordpress_version );
 		$endpoint = $plural_type . '/' . $version;
 
 		$response = $this->call( $endpoint );
-
 
 		$code = wp_remote_retrieve_response_code( $response );
 		$body = wp_remote_retrieve_body( $response );
@@ -518,7 +541,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 		if ( 404 === $code ) {
 			$report[] = array(
-				'title' => "Error generating report for WordPress " . $wp_version,
+				'title' => "Error generating report for WordPress " . $this->wordpress_version,
 				'fix'   => 'n/a',
 			);
 		} else {
@@ -534,7 +557,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					);
 				} else {
 					$report[] = array(
-						'title' => "NVF Error generating report for WordPress " . $wp_version,
+						'title' => "NVF Error generating report for WordPress " . $this->wordpress_version,
 						'fix'   => 'n/a',
 					);
 				}
@@ -555,7 +578,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 							);
 
 							// vuln version, fix available
-						} elseif ( version_compare( $wp_version, $vuln->fixed_in, '<' ) ) {
+						} elseif ( version_compare( $this->wordpress_version, $vuln->fixed_in, '<' ) ) {
 
 							$report[] = array(
 								'title'  => $vuln->title,
@@ -609,7 +632,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			$data[] = array(
 				'name'              => $name,
 				'slug'              => 'wordpress',
-				'installed version' => $wp_version,
+				'installed version' => $this->wordpress_version,
 				'status'            => $stat['title'],
 				'fix'               => $stat['fix'],
 				'action'            => isset( $stat['action'] ) ? $stat['action'] : '',
@@ -948,6 +971,36 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Get the current installed version of WordPress.
+	 *
+	 * @return void
+	 */
+	private function get_wp_version() {
+		global $wp_version;
+		$this->wordpress_version = $wp_version;
+	}
+
+	/**
+	 * Display status results in specified format.
+	 *
+	 * @param string $format The format type string.
+	 *
+	 * @return void
+	 */
+	private function display_formatted_status_results( $format ) {
+		// TODO: Handle outputs in all formats here.
+
+		WP_CLI::log( WP_CLI::colorize( '%GWordPress ' . $this->wordpress_version . ' %n' ) );
+		$this->_do_wordpress();
+
+		WP_CLI::log( WP_CLI::colorize( '%GPlugins%n' ) );
+		$this->_do_plugins();
+
+		WP_CLI::log( WP_CLI::colorize( '%GThemes%n' ) );
+		$this->_do_themes();
 	}
 }
 


### PR DESCRIPTION
This PR seeks to address 2 open issues: https://github.com/10up/wpcli-vulnerability-scanner/issues/23 and https://github.com/10up/wpcli-vulnerability-scanner/issues/24. 

In short, many of the WP CLI commands made available via this plugin should have the capability to return output in various format types (JSON, CSV, etc). Users have been running into issues with several of these format types, so we're looking to test and tidy up those specific cases.

@jeffpaul @TheLastCicada It looks like @pabamato is more or less working on the same enhancements in his PR: https://github.com/10up/wpcli-vulnerability-scanner/pull/51. I'm going to hold off on any further work for now as my project work ramps back up, and until we can determine who should actually be taking ownership of these issues.

@pabamato - I'll keep this PR open for you, as it seems you're further along in resolving this issue. Feel free to leverage my work and let me know if you have any questions!

Thanks everyone!
