### PR TITLE
Update README with installation instructions that work with trunk branch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Check WordPress core, installed plugins and themes for vulnerabilities reported 
 ### Global command, automatically
 It can be installed as a wp-cli package via git repo which is the most preferred way to install.
 ```
-wp --allow-root package install https://github.com/10up/wpcli-vulnerability-scanner/archive/trunk.zip
+wp package install 10up/wpcli-vulnerability-scanner:dev-trunk
 ```
 
 ### WPvulnDB API Access

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Check WordPress core, installed plugins and themes for vulnerabilities reported 
 ### Global command, automatically
 It can be installed as a wp-cli package via git repo which is the most preferred way to install.
 ```
-wp package install git@github.com:10up/wpcli-vulnerability-scanner.git
+wp --allow-root package install https://github.com/10up/wpcli-vulnerability-scanner/archive/trunk.zip
 ```
 
 ### WPvulnDB API Access
@@ -32,7 +32,7 @@ require:
 This repo can be installed as a regular plugin. There is no UI, but the command will become available.
 
 ```
-wp plugin install --activate https://github.com/10up/wpcli-vulnerability-scanner/archive/master.zip
+wp plugin install --activate https://github.com/10up/wpcli-vulnerability-scanner/archive/trunk.zip
 ```
 
 After plugin installation, you can verify the command is in place with `wp help vuln`


### PR DESCRIPTION
Per https://github.com/10up/wpcli-vulnerability-scanner/issues/56, installing via the README instructions using `wp package install` no longer works.  This is because we switched the default branch from `master` to `trunk`.  I think there's likely a path forward with versioned releases that make `wp package install` work even better, but until then, this PR updates the README with installation instructions that actually work, for both `wp package install` and `wp plugin install` using the `.zip` file provided by Github.  