### PR TITLE
Fix false positive report when using fixed vulnerability version.

### DIFF
--- a/features/vuln-plugin-status.feature
+++ b/features/vuln-plugin-status.feature
@@ -9,19 +9,47 @@ Feature: Show vulnerability status for plugins
       Nothing to update
       """
 
-  Scenario: Show vulnerable plugin
+  Scenario: Should not show vulnerable plugin on older version.
     Given a WP install
 
-    When I run `wp plugin install relevant --version=1.0.2 --force`
+    When I run `wp plugin install sassy-social-share --version=3.3.22 --force`
     Then STDOUT should not be empty
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should be a table containing rows:
-      | name     | installed version | status                                                       | fix            |
-      | relevant | 1.0.2             | Relevant Related Posts <= 1.0.7 - Cross-Site Scripting (XSS) | Fixed in 1.0.8 |
+      | name     | installed version | status                                                       | introduced in | fix            |
+      | sassy-social-share | 3.3.22             | No vulnerabilities reported for this version of sassy-social-share | n/a | n/a |
+
+    When I run `wp vuln plugin-status --porcelain`
+    Then STDOUT should be empty
+
+  Scenario: Show vulnerable plugin
+    Given a WP install
+
+    When I run `wp plugin install sassy-social-share --version=3.3.23 --force`
+    Then STDOUT should not be empty
+
+    When I run `wp vuln plugin-status --no-color`
+    Then STDOUT should be a table containing rows:
+      | name     | installed version | status                                                       | introduced in | fix            |
+      | sassy-social-share | 3.3.23             | Sassy Social Share 3.3.23 - Missing Access Controls to PHP Object Injection | 3.3.23 | Fixed in 3.3.24 |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be:
       """
-      relevant
+      sassy-social-share
       """
+
+  Scenario: Should not show vulnerable plugin on fixed version.
+    Given a WP install
+
+    When I run `wp plugin install sassy-social-share --version=3.3.24 --force`
+    Then STDOUT should not be empty
+
+    When I run `wp vuln plugin-status --no-color`
+    Then STDOUT should be a table containing rows:
+      | name     | installed version | status                                                       | introduced in | fix            |
+      | sassy-social-share | 3.3.24             | No vulnerabilities reported for this version of sassy-social-share | n/a | n/a |
+
+    When I run `wp vuln plugin-status --porcelain`
+    Then STDOUT should be empty

--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -586,8 +586,11 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 						// API has records for when was introduced ?
 						$reported_since = $this->obj_has_non_empty_prop( 'introduced_in', $vuln );
+						// Check for fix version.
+						$fixed_since = $this->obj_has_non_empty_prop( 'fixed_in', $vuln );
+
 						// vulnerability that hasn't been fixed :(
-						if ( ! isset( $vuln->fixed_in ) ) {
+						if ( ! $fixed_since ) {
 
 							$report[] = array(
 								'id'            => $vuln->id,
@@ -599,11 +602,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 							// vuln version, fix available.
 						} elseif (
-							// if no records for when it was introduced, compare against current WordPress version.
-							( ! $reported_since && version_compare( $wp_version, $vuln->fixed_in, '<' ) )
+							// If no records for when it was introduced, compare fixed version against current .
+							(
+								! $reported_since
+								&& version_compare( $version, $vuln->fixed_in, '<' )
+							)
 							||
-							// if have records for when it was introduced, compare against current WordPress version.
-							( $reported_since && version_compare( $wp_version, $vuln->introduced_in, '>=' ) )
+							(
+								// If have records for when it was introduced.
+								$reported_since
+								// Check if using version with introduced vulnerablity.
+								&& version_compare( $version, $vuln->introduced_in, '>=' )
+								// Check if using version with vulnerablity fixed.
+								&& version_compare( $version, $vuln->fixed_in, '<' )
+							)
 						) {
 
 							$report[] = array(
@@ -748,9 +760,11 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				foreach ( $vulnerabilities as $k => $vuln ) {
 					// API has records for when was introduced ?
 					$reported_since = $this->obj_has_non_empty_prop( 'introduced_in', $vuln );
+					// Check for fix version.
+					$fixed_since = $this->obj_has_non_empty_prop( 'fixed_in', $vuln );
 
 					// vulnerability that hasn't been fixed :(
-					if ( ! isset( $vuln->fixed_in ) ) {
+					if ( ! $fixed_since ) {
 
 						$report[] = array(
 							'id'            => $vuln->id,
@@ -762,11 +776,20 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 						// vuln version, fix available.
 					} elseif (
-						// if no records for when it was introduced, compare against current WordPress version.
-						( ! $reported_since && version_compare( $version, $vuln->fixed_in, '<' ) )
+						// If no records for when it was introduced, compare fixed version against current .
+						(
+							! $reported_since
+							&& version_compare( $version, $vuln->fixed_in, '<' )
+						)
 						||
-						// if have records for when it was introduced, compare against current WordPress version.
-						( $reported_since && version_compare( $version, $vuln->introduced_in, '>=' ) )
+						(
+							// If have records for when it was introduced.
+							$reported_since
+							// Check if using version with introduced vulnerablity.
+							&& version_compare( $version, $vuln->introduced_in, '>=' )
+							// Check if using version with vulnerablity fixed.
+							&& version_compare( $version, $vuln->fixed_in, '<' )
+						)
 					) {
 
 						$report[] = array(


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

We have recently added `introduced_in` field in https://github.com/10up/wpcli-vulnerability-scanner/pull/50 to show more accurately identify vulnerable versions in report. In this we got one edge case where if we have `introduced_in` field and site already using fixed vulnerability version of plugin/theme it was still flagging it as vulnerable version. As reported in https://github.com/10up/wpcli-vulnerability-scanner/issues/59 

### Alternate Designs

- N/A

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

All use cases of vulnerability check covered:
1. Using version older version of a plugin that is not vulnerable.
2. Using version from which vulnerable was introduced and yet to be fixed.
3. Using version from which vulnerable was introduced and fix version is released but plugin is yet to be updated.
4. Using version in which vulnerability is fixed. 

### Possible Drawbacks

- N/A

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->
Vulnerability report for `sassy-social-share` plugin introduced in 3.3.23 and fixed in 3.3.24.

1. When using plugin older version `3.3.22`
2. Then should not show any vulnerability.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/10358350/143258852-0470d68b-e012-47d1-acd3-3c898d60fb96.png">

1. When using plugin version with vulnerability `3.3.23`
2. Then show vulnerability report.

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/10358350/143260086-af596252-f8ef-49f6-b7c3-3fe5d17b1f45.png">

1. When using plugin version with vulnerability fix`3.3.33`
2. Then should not show any vulnerability.

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/10358350/143260420-4e382709-e265-4f5a-bcc2-ae32fc825d1b.png">


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

Fixes: https://github.com/10up/wpcli-vulnerability-scanner/issues/59

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Changed:
- Fix false positive report for `wp vuln plugin-status` with `introduced_in` field.

