### PR TITLE
Fix autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,14 @@
 		"php": ">=5.4"
 	},
 	"autoload": {
+		"files": [
+			"wpcli-vulnerability-scanner.php"
+		]
+	},
+	"autoload-dev": {
 		"psr-4": {
-			"WP_CLI\\Tests\\": "features"
-		},
-		"files": [ "wpcli-vulnerability-scanner.php" ]
+			"WP_CLI\\Tests\\": "features/"
+		}
 	},
 	"require-dev": {
 		"wp-cli/wp-cli-tests": "^3.1",


### PR DESCRIPTION
Actually this kind of autoloading goes against WP-CLI policies.
Please see the WP-CLI organization here on GitHub.
