### PR TITLE
Fix array to string conversion PHP warning when running with no arguments

### DIFF
--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -121,7 +121,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			$this->_do_nagios_op( array( 'wordpress', 'plugin', 'theme' ) );
 		}
 
-		if ( 'json' == $this->{ $assoc_args }['format'] ) {
+		if ( !empty( $assoc_args ) && ( 'json' == $this->{ $assoc_args }['format'] ) ) {
 			echo '{"core":';
 			$this->_do_wordpress();
 			echo ',"plugins":';

--- a/wpcli-vulnerability-scanner.php
+++ b/wpcli-vulnerability-scanner.php
@@ -121,7 +121,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			$this->_do_nagios_op( array( 'wordpress', 'plugin', 'theme' ) );
 		}
 
-		if ( !empty( $assoc_args ) && ( 'json' == $this->{ $assoc_args }['format'] ) ) {
+		if ( ! empty( $assoc_args ) && ( 'json' == $this->{ $assoc_args }['format'] ) ) {
 			echo '{"core":';
 			$this->_do_wordpress();
 			echo ',"plugins":';


### PR DESCRIPTION
### Description of the Change

Ensures the `$assoc_args` array is not empty before attempting to reference it. This fixes the following PHP warning that appears when running `wp vuln status` with no arguments.

`PHP Warning:  Array to string conversion in /var/www/wpclean.local/wp-content/plugins/wpcli-vulnerability-scanner/wpcli-vulnerability-scanner.php on line 124`

Verified by running with and without arguments before making the change, then repeating after making the change.

Closes #87

### How to test the Change

1. Install this plugin
2. Ensure PHP is [configured to show warnings](https://www.php.net/manual/en/errorfunc.configuration.php)
3. Run `wp vuln status`
4. You should see the PHP warning as described
5. Merge this change
6. Run `wp vuln status`
7. You should no longer see the PHP warning

### Changelog Entry
> Fixed - Array to string conversion PHP warning when running with no arguments

### Credits
Props @ruscoe

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
