### PR TITLE
Rename fix column to "fixed in"

### DIFF
--- a/features/vuln-patchstack.feature
+++ b/features/vuln-patchstack.feature
@@ -19,8 +19,8 @@ Feature: Test WP-CLI Features with Patchstack API.
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                                                      | fixed in                |
-      | wppizza       | 0                 | WordPress WPPizza Plugin <= 2.11.8.0 - Cross Site Scripting | Fixed in 2.11.8.18 |
-      | wordpress-seo | 0                 | WordPress SEO by Yoast Plugin 1.7.3.3 - Blind SQL Injection | Fixed in 1.7.3.4 |
+      | wppizza       | 0                 | WordPress WPPizza Plugin <= 2.11.8.0 - Cross Site Scripting | 2.11.8.18 |
+      | wordpress-seo | 0                 | WordPress SEO by Yoast Plugin 1.7.3.3 - Blind SQL Injection | 1.7.3.4 |
 
 
   Scenario: Get plugin status (wp vuln plugin-status)
@@ -43,7 +43,7 @@ Feature: Test WP-CLI Features with Patchstack API.
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
       | name                   | installed version | status                                                                                         | introduced in | fixed in            |
-      | restricted-site-access | 7.3.1             | WordPress Restricted Site Access plugin <= 7.3.1 - Access Bypass via IP Spoofing vulnerability | <= 7.3.1       | Fixed in 7.3.2 |
+      | restricted-site-access | 7.3.1             | WordPress Restricted Site Access plugin <= 7.3.1 - Access Bypass via IP Spoofing vulnerability | <= 7.3.1       | 7.3.2 |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be:
@@ -70,7 +70,7 @@ Feature: Test WP-CLI Features with Patchstack API.
     When I run `wp vuln theme-check twentyfifteen --version=1.1`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                                                       | fixed in          | 
-      | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | Fixed in 1.2 |
+      | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | 1.2 |
 
   Scenario: Get theme status (wp vuln theme-status)
     When I run `wp vuln theme-status`
@@ -84,7 +84,7 @@ Feature: Test WP-CLI Features with Patchstack API.
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                                                       | introduced in | fixed in          | 
-      | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | <= 1.1         | Fixed in 1.2 |
+      | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | <= 1.1         | 1.2 |
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be:

--- a/features/vuln-patchstack.feature
+++ b/features/vuln-patchstack.feature
@@ -13,12 +13,12 @@ Feature: Test WP-CLI Features with Patchstack API.
   Scenario: Check core status (wp vuln core-status)
     When I run `wp vuln core-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fix |
+      | name | installed version | status | introduced in | fixed in |
 
   Scenario: Check uninstalled vulnerable plugins (wp vuln plugin-check)
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                      | fix                |
+      | name          | installed version | status                                                      | fixed in                |
       | wppizza       | 0                 | WordPress WPPizza Plugin <= 2.11.8.0 - Cross Site Scripting | Fixed in 2.11.8.18 |
       | wordpress-seo | 0                 | WordPress SEO by Yoast Plugin 1.7.3.3 - Blind SQL Injection | Fixed in 1.7.3.4 |
 
@@ -29,7 +29,7 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln plugin-status`
     Then STDOUT should end with a table containing rows:
-      | name    | installed version | status                                                  | introduced in | fix            |
+      | name    | installed version | status                                                  | introduced in | fixed in            |
       | no-mail | 0                 | No vulnerabilities reported for this version of no-mail | n/a           | n/a            |
 
 
@@ -42,7 +42,7 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                                         | introduced in | fix            |
+      | name                   | installed version | status                                                                                         | introduced in | fixed in            |
       | restricted-site-access | 7.3.1             | WordPress Restricted Site Access plugin <= 7.3.1 - Access Bypass via IP Spoofing vulnerability | <= 7.3.1       | Fixed in 7.3.2 |
 
     When I run `wp vuln plugin-status --porcelain`
@@ -60,7 +60,7 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                 | introduced in | fix |
+      | name                   | installed version | status                                                                 | introduced in | fixed in |
       | restricted-site-access | 7.3.2             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a |
 
     When I run `wp vuln plugin-status --porcelain`
@@ -69,13 +69,13 @@ Feature: Test WP-CLI Features with Patchstack API.
   Scenario: Check uninstalled vulnerable themes (wp vuln theme-check)
     When I run `wp vuln theme-check twentyfifteen --version=1.1`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | fix          | 
+      | name          | installed version | status                                                       | fixed in          | 
       | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | Fixed in 1.2 |
 
   Scenario: Get theme status (wp vuln theme-status)
     When I run `wp vuln theme-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fix |
+      | name | installed version | status | introduced in | fixed in |
 
   Scenario: Show vulnerable theme (wp vuln theme-status)
     When I run `wp theme install twentyfifteen --version=1.1 --force`
@@ -83,7 +83,7 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | introduced in | fix          | 
+      | name          | installed version | status                                                       | introduced in | fixed in          | 
       | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | <= 1.1         | Fixed in 1.2 |
 
     When I run `wp vuln theme-status --porcelain`
@@ -98,7 +98,7 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                        | introduced in | fix  | 
+      | name          | installed version | status                                                        | introduced in | fixed in  | 
       | twentyfifteen | 1.2               | No vulnerabilities reported for this version of twentyfifteen | n/a           | n/a  |
 
     When I run `wp vuln theme-status --porcelain`

--- a/features/vuln-wordfence.feature
+++ b/features/vuln-wordfence.feature
@@ -19,8 +19,8 @@ Feature: Test WP-CLI Features with Wordfence API.
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                                                      | fixed in                |
-      | wppizza       | 0                 | PrettyPhoto Library (Multiple Plugins and Themes) <= 3.1.4 - DOM Cross-Site Scripting | Fixed in 2.11.8.18 |
-      | wordpress-seo | 0                 | Yoast SEO <= 3.4.0 - Authenticated Stored Cross-Site Scripting | Fixed in 3.4.1 |
+      | wppizza       | 0                 | PrettyPhoto Library (Multiple Plugins and Themes) <= 3.1.4 - DOM Cross-Site Scripting | 2.11.8.18 |
+      | wordpress-seo | 0                 | Yoast SEO <= 3.4.0 - Authenticated Stored Cross-Site Scripting | 3.4.1 |
 
 
   Scenario: Get plugin status (wp vuln plugin-status)
@@ -43,7 +43,7 @@ Feature: Test WP-CLI Features with Wordfence API.
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
       | name                   | installed version | status                                                                                         | introduced in | fixed in            |
-      | restricted-site-access | 7.3.2             | loader-utils (JS package) < 3.2.1 - Regular Expression Denial of Service | n/a       | Fixed in 7.3.5 |
+      | restricted-site-access | 7.3.2             | loader-utils (JS package) < 3.2.1 - Regular Expression Denial of Service | n/a       | 7.3.5 |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be:
@@ -70,7 +70,7 @@ Feature: Test WP-CLI Features with Wordfence API.
     When I run `wp vuln theme-check twentyfifteen --version=1.1`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                                                       | fixed in          | 
-      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | Fixed in 1.2 |
+      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | 1.2 |
 
   Scenario: Get theme status (wp vuln theme-status)
     When I run `wp vuln theme-status`
@@ -84,7 +84,7 @@ Feature: Test WP-CLI Features with Wordfence API.
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                                                       | introduced in | fixed in          | 
-      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | n/a    | Fixed in 1.2 |
+      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | n/a    | 1.2 |
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be:

--- a/features/vuln-wordfence.feature
+++ b/features/vuln-wordfence.feature
@@ -13,12 +13,12 @@ Feature: Test WP-CLI Features with Wordfence API.
   Scenario: Check core status (wp vuln core-status)
     When I run `wp vuln core-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fix |
+      | name | installed version | status | introduced in | fixed in |
 
   Scenario: Check uninstalled vulnerable plugins (wp vuln plugin-check)
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                      | fix                |
+      | name          | installed version | status                                                      | fixed in                |
       | wppizza       | 0                 | PrettyPhoto Library (Multiple Plugins and Themes) <= 3.1.4 - DOM Cross-Site Scripting | Fixed in 2.11.8.18 |
       | wordpress-seo | 0                 | Yoast SEO <= 3.4.0 - Authenticated Stored Cross-Site Scripting | Fixed in 3.4.1 |
 
@@ -29,7 +29,7 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln plugin-status`
     Then STDOUT should end with a table containing rows:
-      | name    | installed version | status                                                  | introduced in | fix            |
+      | name    | installed version | status                                                  | introduced in | fixed in            |
       | no-mail |                 | No vulnerabilities reported for this version of no-mail | n/a           | n/a            |
 
 
@@ -42,7 +42,7 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                                         | introduced in | fix            |
+      | name                   | installed version | status                                                                                         | introduced in | fixed in            |
       | restricted-site-access | 7.3.2             | loader-utils (JS package) < 3.2.1 - Regular Expression Denial of Service | n/a       | Fixed in 7.3.5 |
 
     When I run `wp vuln plugin-status --porcelain`
@@ -60,7 +60,7 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                 | introduced in | fix |
+      | name                   | installed version | status                                                                 | introduced in | fixed in |
       | restricted-site-access | 7.3.5             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a |
 
     When I run `wp vuln plugin-status --porcelain`
@@ -69,13 +69,13 @@ Feature: Test WP-CLI Features with Wordfence API.
   Scenario: Check uninstalled vulnerable themes (wp vuln theme-check)
     When I run `wp vuln theme-check twentyfifteen --version=1.1`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | fix          | 
+      | name          | installed version | status                                                       | fixed in          | 
       | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | Fixed in 1.2 |
 
   Scenario: Get theme status (wp vuln theme-status)
     When I run `wp vuln theme-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fix |
+      | name | installed version | status | introduced in | fixed in |
 
   Scenario: Show vulnerable theme (wp vuln theme-status)
     When I run `wp theme install twentyfifteen --version=1.1 --force`
@@ -83,7 +83,7 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | introduced in | fix          | 
+      | name          | installed version | status                                                       | introduced in | fixed in          | 
       | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | n/a    | Fixed in 1.2 |
 
     When I run `wp vuln theme-status --porcelain`
@@ -98,7 +98,7 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                        | introduced in | fix  | 
+      | name          | installed version | status                                                        | introduced in | fixed in  | 
       | twentyfifteen | 1.2               | No vulnerabilities reported for this version of twentyfifteen | n/a           | n/a  |
 
     When I run `wp vuln theme-status --porcelain`

--- a/features/vuln-wpscan.feature
+++ b/features/vuln-wpscan.feature
@@ -19,8 +19,8 @@ Feature: Test WP-CLI Features with WPScan API.
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                                                               | fixed in                |
-      | wppizza       | 0                 | Multiple Plugins - jQuery prettyPhoto DOM Cross-Site Scripting (XSS) | Fixed in 2.11.8.18 |
-      | wordpress-seo | 0                 | Yoast SEO - Security issue which allowed any user to reset settings  | Fixed in 1.4.5     |
+      | wppizza       | 0                 | Multiple Plugins - jQuery prettyPhoto DOM Cross-Site Scripting (XSS) | 2.11.8.18 |
+      | wordpress-seo | 0                 | Yoast SEO - Security issue which allowed any user to reset settings  | 1.4.5     |
 
 
   Scenario: Get plugin status (wp vuln plugin-status)
@@ -43,7 +43,7 @@ Feature: Test WP-CLI Features with WPScan API.
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
       | name                   | installed version | status                                                         | introduced in | fixed in            |
-      | restricted-site-access | 7.3.1             | Restricted Site Access < 7.3.2 - Access Bypass via IP Spoofing | n/a           | Fixed in 7.3.2 |
+      | restricted-site-access | 7.3.1             | Restricted Site Access < 7.3.2 - Access Bypass via IP Spoofing | n/a           | 7.3.2 |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be:
@@ -70,7 +70,7 @@ Feature: Test WP-CLI Features with WPScan API.
     When I run `wp vuln theme-check twentyfifteen --version=1.1`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                                                       | fixed in          |
-      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | Fixed in 1.2 |
+      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | 1.2 |
 
   Scenario: Get theme status (wp vuln theme-status)
     When I run `wp vuln theme-status`
@@ -84,7 +84,7 @@ Feature: Test WP-CLI Features with WPScan API.
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                        | introduced in | fixed in            | 
-      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | n/a | Fixed in 1.2 |
+      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | n/a | 1.2 |
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be:

--- a/features/vuln-wpscan.feature
+++ b/features/vuln-wpscan.feature
@@ -13,12 +13,12 @@ Feature: Test WP-CLI Features with WPScan API.
   Scenario: Check core status (wp vuln core-status)
     When I run `wp vuln core-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fix |
+      | name | installed version | status | introduced in | fixed in |
 
   Scenario: Check uninstalled vulnerable plugins (wp vuln plugin-check)
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                               | fix                |
+      | name          | installed version | status                                                               | fixed in                |
       | wppizza       | 0                 | Multiple Plugins - jQuery prettyPhoto DOM Cross-Site Scripting (XSS) | Fixed in 2.11.8.18 |
       | wordpress-seo | 0                 | Yoast SEO - Security issue which allowed any user to reset settings  | Fixed in 1.4.5     |
 
@@ -29,7 +29,7 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln plugin-status`
     Then STDOUT should end with a table containing rows:
-      | name    | installed version | status                              | introduced in | fix |
+      | name    | installed version | status                              | introduced in | fixed in |
       | no-mail |                   | Error generating report for no-mail | n/a           | n/a |
 
 
@@ -42,7 +42,7 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                         | introduced in | fix            |
+      | name                   | installed version | status                                                         | introduced in | fixed in            |
       | restricted-site-access | 7.3.1             | Restricted Site Access < 7.3.2 - Access Bypass via IP Spoofing | n/a           | Fixed in 7.3.2 |
 
     When I run `wp vuln plugin-status --porcelain`
@@ -60,7 +60,7 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                 | introduced in | fix |
+      | name                   | installed version | status                                                                 | introduced in | fixed in |
       | restricted-site-access | 7.3.2             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a |
 
     When I run `wp vuln plugin-status --porcelain`
@@ -69,13 +69,13 @@ Feature: Test WP-CLI Features with WPScan API.
   Scenario: Check uninstalled vulnerable themes (wp vuln theme-check)
     When I run `wp vuln theme-check twentyfifteen --version=1.1`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | fix          |
+      | name          | installed version | status                                                       | fixed in          |
       | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | Fixed in 1.2 |
 
   Scenario: Get theme status (wp vuln theme-status)
     When I run `wp vuln theme-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fix |
+      | name | installed version | status | introduced in | fixed in |
 
   Scenario: Show vulnerable theme (wp vuln theme-status)
     When I run `wp theme install twentyfifteen --version=1.1 --force`
@@ -83,7 +83,7 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                        | introduced in | fix            | 
+      | name          | installed version | status                        | introduced in | fixed in            | 
       | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | n/a | Fixed in 1.2 |
 
     When I run `wp vuln theme-status --porcelain`
@@ -98,7 +98,7 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                        | introduced in | fix  | 
+      | name          | installed version | status                                                        | introduced in | fixed in  | 
       | twentyfifteen | 1.2               | No vulnerabilities reported for this version of twentyfifteen | n/a           | n/a  |
 
     When I run `wp vuln theme-status --porcelain`

--- a/includes/class-vuln-patchstack-service.php
+++ b/includes/class-vuln-patchstack-service.php
@@ -223,7 +223,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 				array(
 					'id'          => '',
 					'action'      => '',
-					'fix'         => 'n/a',
+					'fixed in'    => 'n/a',
 					'affected_in' => 'n/a',
 				)
 			);
@@ -254,7 +254,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 				'installed version' => $version,
 				'id'                => $stat['id'],
 				'status'            => $stat['title'],
-				'fix'               => $stat['fix'],
+				'fixed in'          => $stat['fixed in'],
 				'introduced in'     => $stat['affected_in'],
 				'action'            => $stat['action'],
 			);
@@ -327,7 +327,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 							array(
 								'id'          => '',
 								'action'      => '',
-								'fix'         => 'n/a',
+								'fixed in'    => 'n/a',
 								'affected_in' => 'n/a',
 							)
 						);
@@ -354,7 +354,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 							'installed version' => $version,
 							'id'                => $stat['id'],
 							'status'            => $stat['title'],
-							'fix'               => $stat['fix'],
+							'fixed in'          => $stat['fixed in'],
 							'introduced in'     => $stat['affected_in'],
 							'action'            => $stat['action'],
 						);
@@ -393,7 +393,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 				$report[] = array(
 					'id'          => $vuln->id,
 					'title'       => $vuln->title,
-					'fix'         => 'Not fixed',
+					'fixed in'    => 'Not fixed',
 					'affected_in' => $affected_in ? $vuln->affected_in : 'n/a',
 					'action'      => 'watch',
 				);
@@ -404,7 +404,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 				$report[] = array(
 					'id'          => $vuln->id,
 					'title'       => $vuln->title,
-					'fix'         => "Fixed in {$vuln->fixed_in}",
+					'fixed in'    => $vuln->fixed_in,
 					'affected_in' => $affected_in ? $vuln->affected_in : 'n/a',
 					'action'      => 'update',
 				);

--- a/includes/class-vuln-wordfence-service.php
+++ b/includes/class-vuln-wordfence-service.php
@@ -188,7 +188,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					array(
 						'id'          => '',
 						'action'      => '',
-						'fix'         => 'n/a',
+						'fixed in'    => 'n/a',
 						'affected_in' => 'n/a',
 						'copyrights'  => '',
 					)
@@ -220,7 +220,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					'installed version' => $version,
 					'id'                => $stat['id'],
 					'status'            => $stat['title'],
-					'fix'               => $stat['fix'],
+					'fixed in'          => $stat['fixed in'],
 					'introduced in'     => $stat['affected_in'],
 					'action'            => $stat['action'],
 					'copyrights'        => $stat['copyrights'],
@@ -269,7 +269,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 				$report[] = array(
 					'id'          => $vuln->id,
 					'title'       => $vuln->title,
-					'fix'         => 'Not fixed',
+					'fixed in'    => 'Not fixed',
 					'affected_in' => 'n/a',
 					'action'      => 'watch',
 					'copyrights'  => $vuln->copyrights ? (array) $vuln->copyrights : array(),
@@ -280,7 +280,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 				$report[] = array(
 					'id'          => $vuln->id,
 					'title'       => $vuln->title,
-					'fix'         => "Fixed in {$fixed_version}",
+					'fixed in'    => $fixed_version,
 					'affected_in' => 'n/a',
 					'action'      => 'update',
 					'copyrights'  => $vuln->copyrights ? (array) $vuln->copyrights : array(),

--- a/includes/class-vuln-wpscan-service.php
+++ b/includes/class-vuln-wpscan-service.php
@@ -92,7 +92,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 							$report[] = array(
 								'id'            => $vuln->id,
 								'title'         => $vuln->title,
-								'fix'           => 'Not fixed',
+								'fixed in'      => 'Not fixed',
 								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 								'action'        => 'watch',
 							);
@@ -118,7 +118,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 							$report[] = array(
 								'id'            => $vuln->id,
 								'title'         => $vuln->title,
-								'fix'           => "Fixed in {$vuln->fixed_in}",
+								'fixed in'      => $vuln->fixed_in,
 								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 								'action'        => 'update',
 							);
@@ -152,7 +152,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 				array(
 					'id'            => '',
 					'action'        => '',
-					'fix'           => 'n/a',
+					'fixed in'      => 'n/a',
 					'introduced_in' => 'n/a',
 				)
 			);
@@ -179,7 +179,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 				'installed version' => $wp_version,
 				'id'                => $stat['id'],
 				'status'            => $stat['title'],
-				'fix'               => $stat['fix'],
+				'fixed in'          => $stat['fixed in'],
 				'introduced in'     => $stat['introduced_in'],
 				'action'            => $stat['action'],
 			);
@@ -254,7 +254,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 						$report[] = array(
 							'id'            => $vuln->id,
 							'title'         => $vuln->title,
-							'fix'           => 'Not fixed',
+							'fixed in'      => 'Not fixed',
 							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 							'action'        => 'watch',
 						);
@@ -280,7 +280,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 						$report[] = array(
 							'id'            => $vuln->id,
 							'title'         => $vuln->title,
-							'fix'           => "Fixed in {$vuln->fixed_in}",
+							'fixed in'      => $vuln->fixed_in,
 							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 							'action'        => 'update',
 						);
@@ -314,7 +314,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 				array(
 					'id'            => '',
 					'action'        => '',
-					'fix'           => 'n/a',
+					'fixed in'      => 'n/a',
 					'introduced_in' => 'n/a',
 				)
 			);
@@ -340,7 +340,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 				'installed version' => $version,
 				'id'                => $stat['id'],
 				'status'            => $stat['title'],
-				'fix'               => $stat['fix'],
+				'fixed in'          => $stat['fixed in'],
 				'introduced in'     => $stat['introduced_in'],
 				'action'            => $stat['action'],
 			);

--- a/includes/class-vulnerability-cli.php
+++ b/includes/class-vulnerability-cli.php
@@ -109,7 +109,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 			$this->do_nagios_op( array( 'wordpress', 'plugin', 'theme' ) );
 		}
 
-		if ( 'json' === $this->{ $assoc_args }['format'] ) {
+		if ( 'json' === $format ) {
 			echo '{"core":';
 			$this->do_wordpress();
 			echo ',"plugins":';
@@ -337,7 +337,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'name',
 				'installed version',
 				'status',
-				'fix',
+				'fixed in',
 			),
 			'themes'
 		);
@@ -399,7 +399,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'name',
 				'installed version',
 				'status',
-				'fix',
+				'fixed in',
 			),
 			'plugins'
 		);
@@ -462,7 +462,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					'installed version',
 					'status',
 					'introduced in',
-					'fix',
+					'fixed in',
 				),
 				$plural_type
 			);
@@ -539,7 +539,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					'installed version',
 					'status',
 					'introduced in',
-					'fix',
+					'fixed in',
 				),
 				$plural_type
 			);
@@ -625,7 +625,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				$wp_vulns = $this->service->check_wordpress();
 				if ( ! empty( $wp_vulns ) && is_array( $wp_vulns ) ) {
 					foreach ( $wp_vulns as $wp_vuln ) {
-						if ( isset( $wp_vuln['fix'] ) && 'n/a' !== $wp_vuln['fix'] ) {
+						if ( isset( $wp_vuln['fixed in'] ) && 'n/a' !== $wp_vuln['fixed in'] ) {
 							$wp_list ++;
 						}
 					}
@@ -635,7 +635,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				$plugins = $this->service->check_thing( 'plugin' );
 				if ( ! empty( $plugins ) && is_array( $plugins ) ) {
 					foreach ( $plugins as $plugin ) {
-						if ( isset( $plugin['fix'] ) && 'n/a' !== $plugin['fix'] ) {
+						if ( isset( $plugin['fixed in'] ) && 'n/a' !== $plugin['fixed in'] ) {
 							$pl_list ++;
 						}
 					}
@@ -645,7 +645,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				$themes = $this->service->check_thing( 'theme' );
 				if ( ! empty( $themes ) && is_array( $themes ) ) {
 					foreach ( $themes as $theme ) {
-						if ( isset( $theme['fix'] ) && 'n/a' !== $theme['fix'] ) {
+						if ( isset( $theme['fixed in'] ) && 'n/a' !== $theme['fixed in'] ) {
 							$th_list ++;
 						}
 					}


### PR DESCRIPTION
### Description of the Change
PR contains a minor change to rename the `fix` column to `fixed in` as requested in #83 

Closes #83 

### How to test the Change
1. Checkout to this PR branch
2. Try running commands like `wp vuln status`, `wp vuln core-status`, `wp vuln plugin status`, etc...
3. Notice the `fixed in` column is there (it was `fix` earlier)
4. Try running commands with different arguments like format etc...


### Changelog Entry
> Changed - Renamed "fix" column to "fixed in"


### Credits
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
