### PR TITLE
Add vulnerability severity data to command output.

### DIFF
--- a/features/vuln-patchstack.feature
+++ b/features/vuln-patchstack.feature
@@ -13,14 +13,14 @@ Feature: Test WP-CLI Features with Patchstack API.
   Scenario: Check core status (wp vuln core-status)
     When I run `wp vuln core-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fixed in |
+      | name | installed version | status | introduced in | fixed in | severity |
 
   Scenario: Check uninstalled vulnerable plugins (wp vuln plugin-check)
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                      | fixed in                |
-      | wppizza       | 0                 | WordPress WPPizza Plugin <= 2.11.8.0 - Cross Site Scripting | 2.11.8.18 |
-      | wordpress-seo | 0                 | WordPress SEO by Yoast Plugin 1.7.3.3 - Blind SQL Injection | 1.7.3.4 |
+      | name          | installed version | status                                                      | fixed in                | severity      |
+      | wppizza       | 0                 | WordPress WPPizza Plugin <= 2.11.8.0 - Cross Site Scripting | 2.11.8.18 | n/a           |
+      | wordpress-seo | 0                 | WordPress SEO by Yoast Plugin 1.7.3.3 - Blind SQL Injection | 1.7.3.4 | n/a           |
 
 
   Scenario: Get plugin status (wp vuln plugin-status)
@@ -29,8 +29,8 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln plugin-status`
     Then STDOUT should end with a table containing rows:
-      | name    | installed version | status                                                  | introduced in | fixed in            |
-      | no-mail | 0                 | No vulnerabilities reported for this version of no-mail | n/a           | n/a            |
+      | name    | installed version | status                                                  | introduced in | fixed in            | severity |
+      | no-mail | 0                 | No vulnerabilities reported for this version of no-mail | n/a           | n/a            | n/a           |
 
 
   Scenario: Show vulnerable plugin (wp vuln plugin-status)
@@ -42,8 +42,8 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                                         | introduced in | fixed in            |
-      | restricted-site-access | 7.3.1             | WordPress Restricted Site Access plugin <= 7.3.1 - Access Bypass via IP Spoofing vulnerability | <= 7.3.1       | 7.3.2 |
+      | name                   | installed version | status                                                                                         | introduced in | fixed in            | severity      |
+      | restricted-site-access | 7.3.1             | WordPress Restricted Site Access plugin <= 7.3.1 - Access Bypass via IP Spoofing vulnerability | <= 7.3.1       | 7.3.2 | Medium 5.3/10 |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be:
@@ -60,8 +60,8 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                 | introduced in | fixed in |
-      | restricted-site-access | 7.3.2             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a |
+      | name                   | installed version | status                                                                 | introduced in | fixed in | severity |
+      | restricted-site-access | 7.3.2             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a | n/a      |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be empty
@@ -69,13 +69,13 @@ Feature: Test WP-CLI Features with Patchstack API.
   Scenario: Check uninstalled vulnerable themes (wp vuln theme-check)
     When I run `wp vuln theme-check twentyfifteen --version=1.1`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | fixed in          | 
-      | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | 1.2 |
+      | name          | installed version | status                                                       | fixed in          | severity |
+      | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | 1.2 | n/a      |
 
   Scenario: Get theme status (wp vuln theme-status)
     When I run `wp vuln theme-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fixed in |
+      | name | installed version | status | introduced in | fixed in | severity |
 
   Scenario: Show vulnerable theme (wp vuln theme-status)
     When I run `wp theme install twentyfifteen --version=1.1 --force`
@@ -83,8 +83,8 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | introduced in | fixed in          | 
-      | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | <= 1.1         | 1.2 |
+      | name          | installed version | status                                                       | introduced in | fixed in          | severity |
+      | twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | <= 1.1         | 1.2 | n/a      |
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be:
@@ -98,8 +98,8 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                        | introduced in | fixed in  | 
-      | twentyfifteen | 1.2               | No vulnerabilities reported for this version of twentyfifteen | n/a           | n/a  |
+      | name          | installed version | status                                                        | introduced in | fixed in  | severity |
+      | twentyfifteen | 1.2               | No vulnerabilities reported for this version of twentyfifteen | n/a           | n/a  | n/a      |
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be empty

--- a/features/vuln-patchstack.feature
+++ b/features/vuln-patchstack.feature
@@ -107,4 +107,4 @@ Feature: Test WP-CLI Features with Patchstack API.
   Scenario: Should show reference information on request (wp vuln core-status --reference)
     When I run `wp vuln core-status --reference`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fixed in | reference |
+      | name | installed version | status | introduced in | fixed in | severity | reference |

--- a/features/vuln-wordfence.feature
+++ b/features/vuln-wordfence.feature
@@ -19,7 +19,8 @@ Feature: Test WP-CLI Features with Wordfence API.
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
       | name          | installed version | status                                                      | fixed in                | severity |
-      | wppizza       | 0                 | PrettyPhoto Library (Multiple Plugins and Themes) <= 3.1.4 - DOM Cross-Site Scripting | 2.11.8.18 | Medium 6.1/10 |
+      | wppizza       | 0                 | WPPizza <= 3.17.1 - Reflected Cross-Site Scripting | 3.17.2 | Medium 6.1/10 |
+      | | 0                 | PrettyPhoto Library (Multiple Plugins and Themes) <= 3.1.4 - DOM Cross-Site Scripting | 2.11.8.18 | Medium 6.1/10 |
       | wordpress-seo | 0                 | Yoast SEO <= 3.4.0 - Authenticated Stored Cross-Site Scripting | 3.4.1 | Medium 5.4/10 |
 
 
@@ -43,7 +44,7 @@ Feature: Test WP-CLI Features with Wordfence API.
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
       | name                   | installed version | status                                                                                         | introduced in | fixed in            | severity |
-      | restricted-site-access | 7.3.2             | loader-utils (JS package) < 3.2.1 - Regular Expression Denial of Service | n/a       | 7.3.5 | Low 3.7/10 |
+      | restricted-site-access | 7.3.2             | webpack JS package <= 5.75.0 - Sandbox Bypass | n/a       | 7.4.0 | High 8.3/10 |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be:
@@ -55,13 +56,13 @@ Feature: Test WP-CLI Features with Wordfence API.
     When I run `wp plugin uninstall akismet hello`
     Then STDOUT should not be empty
 
-    When I run `wp plugin install restricted-site-access --version=7.3.5 --force`
+    When I run `wp plugin install restricted-site-access --version=7.4.0 --force`
     Then STDOUT should not be empty
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
       | name                   | installed version | status                                                                 | introduced in | fixed in | severity |
-      | restricted-site-access | 7.3.5             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a | n/a      |
+      | restricted-site-access | 7.4.0             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a | n/a      |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be empty

--- a/features/vuln-wordfence.feature
+++ b/features/vuln-wordfence.feature
@@ -13,14 +13,14 @@ Feature: Test WP-CLI Features with Wordfence API.
   Scenario: Check core status (wp vuln core-status)
     When I run `wp vuln core-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fixed in |
+      | name | installed version | status | introduced in | fixed in | severity |
 
   Scenario: Check uninstalled vulnerable plugins (wp vuln plugin-check)
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                      | fixed in                |
-      | wppizza       | 0                 | PrettyPhoto Library (Multiple Plugins and Themes) <= 3.1.4 - DOM Cross-Site Scripting | 2.11.8.18 |
-      | wordpress-seo | 0                 | Yoast SEO <= 3.4.0 - Authenticated Stored Cross-Site Scripting | 3.4.1 |
+      | name          | installed version | status                                                      | fixed in                | severity |
+      | wppizza       | 0                 | PrettyPhoto Library (Multiple Plugins and Themes) <= 3.1.4 - DOM Cross-Site Scripting | 2.11.8.18 | Medium 6.1/10 |
+      | wordpress-seo | 0                 | Yoast SEO <= 3.4.0 - Authenticated Stored Cross-Site Scripting | 3.4.1 | Medium 5.4/10 |
 
 
   Scenario: Get plugin status (wp vuln plugin-status)
@@ -29,8 +29,8 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln plugin-status`
     Then STDOUT should end with a table containing rows:
-      | name    | installed version | status                                                  | introduced in | fixed in            |
-      | no-mail |                 | No vulnerabilities reported for this version of no-mail | n/a           | n/a            |
+      | name    | installed version | status                                                  | introduced in | fixed in            | severity |
+      | no-mail |                 | No vulnerabilities reported for this version of no-mail | n/a           | n/a            | n/a      |
 
 
   Scenario: Show vulnerable plugin (wp vuln plugin-status)
@@ -42,8 +42,8 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                                         | introduced in | fixed in            |
-      | restricted-site-access | 7.3.2             | loader-utils (JS package) < 3.2.1 - Regular Expression Denial of Service | n/a       | 7.3.5 |
+      | name                   | installed version | status                                                                                         | introduced in | fixed in            | severity |
+      | restricted-site-access | 7.3.2             | loader-utils (JS package) < 3.2.1 - Regular Expression Denial of Service | n/a       | 7.3.5 | Low 3.7/10 |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be:
@@ -60,8 +60,8 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                 | introduced in | fixed in |
-      | restricted-site-access | 7.3.5             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a |
+      | name                   | installed version | status                                                                 | introduced in | fixed in | severity |
+      | restricted-site-access | 7.3.5             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a | n/a      |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be empty
@@ -69,13 +69,13 @@ Feature: Test WP-CLI Features with Wordfence API.
   Scenario: Check uninstalled vulnerable themes (wp vuln theme-check)
     When I run `wp vuln theme-check twentyfifteen --version=1.1`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | fixed in          | 
-      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | 1.2 |
+      | name          | installed version | status                                                       | fixed in          |  severity |
+      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | 1.2 | Medium 6.4/10 |
 
   Scenario: Get theme status (wp vuln theme-status)
     When I run `wp vuln theme-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fixed in |
+      | name | installed version | status | introduced in | fixed in | severity |
 
   Scenario: Show vulnerable theme (wp vuln theme-status)
     When I run `wp theme install twentyfifteen --version=1.1 --force`
@@ -83,8 +83,8 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | introduced in | fixed in          | 
-      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | n/a    | 1.2 |
+      | name          | installed version | status                                                       | introduced in | fixed in          |  severity |
+      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 & WordPress Core < 4.2.2 - Cross-Site Scripting via example.html | n/a    | 1.2 | Medium 6.4/10 |
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be:
@@ -98,8 +98,8 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                        | introduced in | fixed in  | 
-      | twentyfifteen | 1.2               | No vulnerabilities reported for this version of twentyfifteen | n/a           | n/a  |
+      | name          | installed version | status                                                        | introduced in | fixed in  | severity | 
+      | twentyfifteen | 1.2               | No vulnerabilities reported for this version of twentyfifteen | n/a           | n/a  | n/a      |
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be empty

--- a/features/vuln-wordfence.feature
+++ b/features/vuln-wordfence.feature
@@ -108,4 +108,4 @@ Feature: Test WP-CLI Features with Wordfence API.
   Scenario: Should show reference information on request (wp vuln core-status --reference)
     When I run `wp vuln core-status --reference`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fixed in | reference |
+      | name | installed version | status | introduced in | fixed in | severity | reference |

--- a/features/vuln-wpscan.feature
+++ b/features/vuln-wpscan.feature
@@ -13,14 +13,14 @@ Feature: Test WP-CLI Features with WPScan API.
   Scenario: Check core status (wp vuln core-status)
     When I run `wp vuln core-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fixed in |
+      | name | installed version | status | introduced in | fixed in | severity |
 
   Scenario: Check uninstalled vulnerable plugins (wp vuln plugin-check)
     When I run `wp vuln plugin-check wppizza wordpress-seo`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                               | fixed in                |
-      | wppizza       | 0                 | Multiple Plugins - jQuery prettyPhoto DOM Cross-Site Scripting (XSS) | 2.11.8.18 |
-      | wordpress-seo | 0                 | Yoast SEO - Security issue which allowed any user to reset settings  | 1.4.5     |
+      | name          | installed version | status                                                               | fixed in  | severity |
+      | wppizza       | 0                 | Multiple Plugins - jQuery prettyPhoto DOM Cross-Site Scripting (XSS) | 2.11.8.18 | n/a      |
+      | wordpress-seo | 0                 | Yoast SEO - Security issue which allowed any user to reset settings  | 1.4.5     | n/a      |
 
 
   Scenario: Get plugin status (wp vuln plugin-status)
@@ -29,8 +29,8 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln plugin-status`
     Then STDOUT should end with a table containing rows:
-      | name    | installed version | status                              | introduced in | fixed in |
-      | no-mail |                   | Error generating report for no-mail | n/a           | n/a |
+      | name    | installed version | status                              | introduced in | fixed in | severity |
+      | no-mail |                   | Error generating report for no-mail | n/a           | n/a      | n/a      |
 
 
   Scenario: Show vulnerable plugin (wp vuln plugin-status)
@@ -42,8 +42,8 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                         | introduced in | fixed in            |
-      | restricted-site-access | 7.3.1             | Restricted Site Access < 7.3.2 - Access Bypass via IP Spoofing | n/a           | 7.3.2 |
+      | name                   | installed version | status                                                         | introduced in | fixed in            | severity |
+      | restricted-site-access | 7.3.1             | Restricted Site Access < 7.3.2 - Access Bypass via IP Spoofing | n/a           | 7.3.2 | n/a      |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be:
@@ -60,8 +60,8 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln plugin-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name                   | installed version | status                                                                 | introduced in | fixed in |
-      | restricted-site-access | 7.3.2             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a |
+      | name                   | installed version | status                                                                 | introduced in | fixed in | severity |
+      | restricted-site-access | 7.3.2             | No vulnerabilities reported for this version of restricted-site-access | n/a           | n/a      | n/a      |
 
     When I run `wp vuln plugin-status --porcelain`
     Then STDOUT should be empty
@@ -69,13 +69,13 @@ Feature: Test WP-CLI Features with WPScan API.
   Scenario: Check uninstalled vulnerable themes (wp vuln theme-check)
     When I run `wp vuln theme-check twentyfifteen --version=1.1`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                       | fixed in          |
-      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | 1.2 |
+      | name          | installed version | status                                                       | fixed in | severity |
+      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | 1.2      | n/a      |
 
   Scenario: Get theme status (wp vuln theme-status)
     When I run `wp vuln theme-status`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fixed in |
+      | name | installed version | status | introduced in | fixed in | severity |
 
   Scenario: Show vulnerable theme (wp vuln theme-status)
     When I run `wp theme install twentyfifteen --version=1.1 --force`
@@ -83,8 +83,8 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                        | introduced in | fixed in            | 
-      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | n/a | 1.2 |
+      | name          | installed version | status                        | introduced in | fixed in                 | severity |
+      | twentyfifteen | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | n/a | 1.2 | n/a      |
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be:
@@ -98,8 +98,8 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln theme-status --no-color`
     Then STDOUT should end with a table containing rows:
-      | name          | installed version | status                                                        | introduced in | fixed in  | 
-      | twentyfifteen | 1.2               | No vulnerabilities reported for this version of twentyfifteen | n/a           | n/a  |
+      | name          | installed version | status                                                        | introduced in | fixed in  | severity |
+      | twentyfifteen | 1.2               | No vulnerabilities reported for this version of twentyfifteen | n/a           | n/a  | n/a      |
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be empty

--- a/features/vuln-wpscan.feature
+++ b/features/vuln-wpscan.feature
@@ -107,4 +107,4 @@ Feature: Test WP-CLI Features with WPScan API.
   Scenario: Should show reference information on request (wp vuln core-status --reference)
     When I run `wp vuln core-status --reference`
     Then STDOUT should end with a table containing rows:
-      | name | installed version | status | introduced in | fixed in | reference |
+      | name | installed version | status | introduced in | fixed in | severity | reference |

--- a/includes/class-vuln-patchstack-service.php
+++ b/includes/class-vuln-patchstack-service.php
@@ -224,6 +224,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 					'id'          => '',
 					'action'      => '',
 					'fixed in'    => 'n/a',
+					'severity'    => 'n/a',
 					'affected_in' => 'n/a',
 				)
 			);
@@ -255,6 +256,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 				'id'                => $stat['id'],
 				'status'            => $stat['title'],
 				'fixed in'          => $stat['fixed in'],
+				'severity'          => $stat['severity'],
 				'introduced in'     => $stat['affected_in'],
 				'action'            => $stat['action'],
 			);
@@ -328,6 +330,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 								'id'          => '',
 								'action'      => '',
 								'fixed in'    => 'n/a',
+								'severity'    => 'n/a',
 								'affected_in' => 'n/a',
 							)
 						);
@@ -355,6 +358,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 							'id'                => $stat['id'],
 							'status'            => $stat['title'],
 							'fixed in'          => $stat['fixed in'],
+							'severity'          => $stat['severity'],
 							'introduced in'     => $stat['affected_in'],
 							'action'            => $stat['action'],
 						);
@@ -394,6 +398,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 					'id'          => $vuln->id,
 					'title'       => $vuln->title,
 					'fixed in'    => 'Not fixed',
+					'severity'    => $this->get_severity_value( $vuln->cvss_score ),
 					'affected_in' => $affected_in ? $vuln->affected_in : 'n/a',
 					'action'      => 'watch',
 				);
@@ -405,6 +410,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 					'id'          => $vuln->id,
 					'title'       => $vuln->title,
 					'fixed in'    => $vuln->fixed_in,
+					'severity'    => $this->get_severity_value( $vuln->cvss_score ),
 					'affected_in' => $affected_in ? $vuln->affected_in : 'n/a',
 					'action'      => 'update',
 				);

--- a/includes/class-vuln-service.php
+++ b/includes/class-vuln-service.php
@@ -126,4 +126,36 @@ class Vuln_Service {
 
 		return $list;
 	}
+
+	/**
+	 * Get formatted Serverity column value based on score.
+	 *
+	 * @param float $csvv_score
+	 * @return string
+	 */
+	protected function get_severity_value( $csvv_score ) {
+		if ( empty( $csvv_score ) ) {
+			return 'n/a';
+		}
+		
+		if ( ! is_float( $csvv_score ) ) {
+			$csvv_score = (float) $csvv_score;
+		}
+
+		$severity_ratting = '';
+
+		if ( $csvv_score >= 9 ) {
+			$severity_ratting = 'Critical';
+		} elseif ( $csvv_score >= 7 ) {
+			$severity_ratting = 'High';
+		} elseif ( $csvv_score >= 4 ) {
+			$severity_ratting = 'Medium';
+		} elseif ( $csvv_score > 0 ) {
+			$severity_ratting = 'Low';
+		} elseif ( (float) 0 === $csvv_score ) {
+			$severity_ratting = 'None';
+		}
+
+		return sprintf( '%s %.1f/10', $severity_ratting, $csvv_score );
+	}
 }

--- a/includes/class-vuln-service.php
+++ b/includes/class-vuln-service.php
@@ -137,7 +137,7 @@ class Vuln_Service {
 		if ( empty( $csvv_score ) ) {
 			return 'n/a';
 		}
-		
+
 		if ( ! is_float( $csvv_score ) ) {
 			$csvv_score = (float) $csvv_score;
 		}

--- a/includes/class-vuln-wordfence-service.php
+++ b/includes/class-vuln-wordfence-service.php
@@ -359,58 +359,28 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 	 * If local cache file exists, use it.
 	 * Otherwise, get data from Wordfence API and cache it locally for 1 hour.
 	 *
-	 * @return array|WP_Error $vuln_data Array of Vulnerability.
+	 * @return JsonMachine\Items|WP_Error $vuln_data Array of Vulnerability.
 	 */
 	private function get_vulnerability_data() {
 		$wp_filesystem = $this->init_wp_filesystem();
-		$file_path     = $this->get_vuln_db_filepath();
-		$vuln_data     = array();
 
-		// Check for cached local vuln db file.
-		if ( $wp_filesystem->exists( $file_path ) ) {
+		$key       = 'vuln_check-' . md5( $this->api_url );
+		$file_path = get_transient( $key );
+
+		if ( $file_path && $wp_filesystem->exists( $file_path ) ) {
 			WP_CLI::debug( 'Using local cached vuln db json' );
-			$vuln_data = JsonMachine\Items::fromFile( $file_path );
 		} else {
-			// Get vulnerability data from Wordfence API and cache it locally for 1 hour.
 			WP_CLI::debug( 'Request Wordfence API for vuln db json' );
-			$response = wp_remote_get(
-				$this->api_url,
-				array(
-					'headers' => array(
-						'Accept' => 'application/json',
-					),
-					'timeout' => 60,
-				)
-			);
-
-			$code = wp_remote_retrieve_response_code( $response );
-			if ( 429 === $code ) {
-				return new WP_Error( 'error_api_quota_full', 'ERROR_API_QUOTA_FULL: exceed daily rate limit hit.' );
-			} elseif ( 404 === $code ) {
-				return new WP_Error( 'vuln_db_error', 'Unable to retrieve vulnerability data.' );
+			$vuln_db_file = download_url( $this->api_url );
+			if ( is_wp_error( $vuln_db_file ) ) {
+				return $vuln_db_file;
 			}
 
-			if ( ( ! is_wp_error( $response ) ) && ( 200 === wp_remote_retrieve_response_code( $response ) ) ) {
-				if ( ! $wp_filesystem->put_contents( $file_path, $response['body'] ) ) {
-					WP_CLI::error( 'Error creating local json file.' );
-				}
-				$vuln_data = JsonMachine\Items::fromFile( $file_path );
-			}
+			$file_path = $vuln_db_file;
+			set_transient( $key, $file_path, HOUR_IN_SECONDS );
 		}
-		return $vuln_data;
-	}
 
-	/**
-	 * Get the vulnerability database file path.
-	 * The file is cached for 1 hour (Filename will be different for every hour).
-	 *
-	 * @return string
-	 */
-	private function get_vuln_db_filepath() {
-		$tmp_dir = get_temp_dir();
-		$date    = ( new DateTime() )->format( 'YmdH' );
-
-		return $tmp_dir . 'wordfence-vuln-db-' . $date . '.json';
+		return JsonMachine\Items::fromFile( $file_path );
 	}
 
 	/**

--- a/includes/class-vuln-wordfence-service.php
+++ b/includes/class-vuln-wordfence-service.php
@@ -11,7 +11,7 @@ if ( ! defined( 'WP_CLI' ) ) {
 
 // API URL constant defined so we can override it if needed.
 if ( ! defined( 'WORDFENCE_API_URL' ) ) {
-	define( 'WORDFENCE_API_URL', 'https://www.wordfence.com/api/intelligence/v2/vulnerabilities/scanner' );
+	define( 'WORDFENCE_API_URL', 'https://www.wordfence.com/api/intelligence/v2/vulnerabilities/production' );
 }
 
 /**
@@ -190,6 +190,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 						'action'      => '',
 						'fixed in'    => 'n/a',
 						'affected_in' => 'n/a',
+						'severity'    => 'n/a',
 						'copyrights'  => '',
 					)
 				);
@@ -223,6 +224,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					'fixed in'          => $stat['fixed in'],
 					'introduced in'     => $stat['affected_in'],
 					'action'            => $stat['action'],
+					'severity'          => $stat['severity'],
 					'copyrights'        => $stat['copyrights'],
 				);
 
@@ -246,6 +248,10 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 		foreach ( $vulnerabilities as $vuln ) {
 			$fixed         = false;
 			$fixed_version = '';
+			$severity      = 'n/a';
+			if ( ! empty( $vuln->cvss ) ) {
+				$severity = sprintf( '%s %.1f/10', $vuln->cvss->rating, $vuln->cvss->score );
+			}
 
 			foreach ( $vuln->software as $software ) {
 				if ( $software->slug === $slug ) {
@@ -272,6 +278,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					'fixed in'    => 'Not fixed',
 					'affected_in' => 'n/a',
 					'action'      => 'watch',
+					'severity'    => $severity,
 					'copyrights'  => $vuln->copyrights ? (array) $vuln->copyrights : array(),
 				);
 
@@ -283,6 +290,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					'fixed in'    => $fixed_version,
 					'affected_in' => 'n/a',
 					'action'      => 'update',
+					'severity'    => $severity,
 					'copyrights'  => $vuln->copyrights ? (array) $vuln->copyrights : array(),
 				);
 			}

--- a/includes/class-vuln-wpscan-service.php
+++ b/includes/class-vuln-wpscan-service.php
@@ -93,6 +93,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 								'id'            => $vuln->id,
 								'title'         => $vuln->title,
 								'fixed in'      => 'Not fixed',
+								'severity'      => $this->get_severity_value( $vuln->cvss ),
 								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 								'action'        => 'watch',
 							);
@@ -119,6 +120,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 								'id'            => $vuln->id,
 								'title'         => $vuln->title,
 								'fixed in'      => $vuln->fixed_in,
+								'severity'      => $this->get_severity_value( $vuln->cvss ),
 								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 								'action'        => 'update',
 							);
@@ -153,6 +155,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 					'id'            => '',
 					'action'        => '',
 					'fixed in'      => 'n/a',
+					'severity'      => 'n/a',
 					'introduced_in' => 'n/a',
 				)
 			);
@@ -180,6 +183,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 				'id'                => $stat['id'],
 				'status'            => $stat['title'],
 				'fixed in'          => $stat['fixed in'],
+				'severity'          => $stat['severity'],
 				'introduced in'     => $stat['introduced_in'],
 				'action'            => $stat['action'],
 			);
@@ -255,6 +259,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 							'id'            => $vuln->id,
 							'title'         => $vuln->title,
 							'fixed in'      => 'Not fixed',
+							'severity'      => $this->get_severity_value( $vuln->cvss ),
 							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 							'action'        => 'watch',
 						);
@@ -281,6 +286,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 							'id'            => $vuln->id,
 							'title'         => $vuln->title,
 							'fixed in'      => $vuln->fixed_in,
+							'severity'      => $this->get_severity_value( $vuln->cvss ),
 							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
 							'action'        => 'update',
 						);
@@ -315,6 +321,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 					'id'            => '',
 					'action'        => '',
 					'fixed in'      => 'n/a',
+					'severity'      => 'n/a',
 					'introduced_in' => 'n/a',
 				)
 			);
@@ -341,6 +348,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 				'id'                => $stat['id'],
 				'status'            => $stat['title'],
 				'fixed in'          => $stat['fixed in'],
+				'severity'          => $stat['severity'],
 				'introduced in'     => $stat['introduced_in'],
 				'action'            => $stat['action'],
 			);

--- a/includes/class-vulnerability-cli.php
+++ b/includes/class-vulnerability-cli.php
@@ -338,6 +338,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'installed version',
 				'status',
 				'fixed in',
+				'severity',
 			),
 			'themes'
 		);
@@ -400,6 +401,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				'installed version',
 				'status',
 				'fixed in',
+				'severity',
 			),
 			'plugins'
 		);
@@ -463,6 +465,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					'status',
 					'introduced in',
 					'fixed in',
+					'severity',
 				),
 				$plural_type
 			);
@@ -471,6 +474,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				$display,
 				array(
 					true,
+					false,
 					false,
 					false,
 					false,
@@ -540,6 +544,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 					'status',
 					'introduced in',
 					'fixed in',
+					'severity',
 				),
 				$plural_type
 			);
@@ -548,6 +553,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 				$display,
 				array(
 					true,
+					false,
 					false,
 					false,
 					false,

--- a/readme.md
+++ b/readme.md
@@ -111,25 +111,25 @@ $ wp vuln status
 
 Vulnerability API Provider: Patchstack
 WordPress 6.2.2
-+-----------+-------------------+-----------------------------------------------------------+---------------+----------+
-| name      | installed version | status                                                    | introduced in | fixed in |
-+-----------+-------------------+-----------------------------------------------------------+---------------+----------+
-| WordPress | 6.2.2             | No vulnerabilities reported for this version of WordPress | n/a           | n/a      |
-+-----------+-------------------+-----------------------------------------------------------+---------------+----------+
++-----------+-------------------+-----------------------------------------------------------+---------------+----------+----------+
+| name      | installed version | status                                                    | introduced in | fixed in | severity |
++-----------+-------------------+-----------------------------------------------------------+---------------+----------+----------+
+| WordPress | 6.2.2             | No vulnerabilities reported for this version of WordPress | n/a           | n/a      | n/a      |
++-----------+-------------------+-----------------------------------------------------------+---------------+----------+----------+
 Plugins
-+-----------------------------+-------------------+----------------------------------------------------------------------------------------------------------------+---------------+----------+
-| name                        | installed version | status                                                                                                         | introduced in | fixed in |
-+-----------------------------+-------------------+----------------------------------------------------------------------------------------------------------------+---------------+----------+
-| simple-podcasting           | 1.5.0             | No vulnerabilities reported for this version of simple-podcasting                                              | n/a           | n/a      |
-| woocommerce                 | 7.8.2             | No vulnerabilities reported for this version of woocommerce                                                    | n/a           | n/a      |
-| wordpress-seo               | 20.2              | Wordpress Yoast SEO plugin <= 20.2 - Authenticated (Contributor+) DOM-Based Cross-Site Scripting vulnerability | <= 20.2       | 20.2.1   |
-+-----------------------------+-------------------+----------------------------------------------------------------------------------------------------------------+---------------+----------+
++-----------------------------+-------------------+----------------------------------------------------------------------------------------------------------------+---------------+----------+---------------+
+| name                        | installed version | status                                                                                                         | introduced in | fixed in | severity      |
++-----------------------------+-------------------+----------------------------------------------------------------------------------------------------------------+---------------+----------+---------------+
+| simple-podcasting           | 1.5.0             | No vulnerabilities reported for this version of simple-podcasting                                              | n/a           | n/a      | n/a           |
+| woocommerce                 | 7.8.2             | No vulnerabilities reported for this version of woocommerce                                                    | n/a           | n/a      | n/a           |
+| wordpress-seo               | 20.2              | Wordpress Yoast SEO plugin <= 20.2 - Authenticated (Contributor+) DOM-Based Cross-Site Scripting vulnerability | <= 20.2       | 20.2.1   | Medium 6.5/10 |
++-----------------------------+-------------------+----------------------------------------------------------------------------------------------------------------+---------------+----------+---------------+
 Themes
-+-------------------+-------------------+-------------------------------------------------------------------+---------------+----------+
-| name              | installed version | status                                                            | introduced in | fixed in |
-+-------------------+-------------------+-------------------------------------------------------------------+---------------+----------+
-| twentytwentythree | 1.1               | No vulnerabilities reported for this version of twentytwentythree | n/a           | n/a      |
-+-------------------+-------------------+-------------------------------------------------------------------+---------------+----------+
++-------------------+-------------------+-------------------------------------------------------------------+---------------+----------+----------+
+| name              | installed version | status                                                            | introduced in | fixed in | severity |
++-------------------+-------------------+-------------------------------------------------------------------+---------------+----------+----------+
+| twentytwentythree | 1.1               | No vulnerabilities reported for this version of twentytwentythree | n/a           | n/a      | n/a      |
++-------------------+-------------------+-------------------------------------------------------------------+---------------+----------+----------+
 ```
 
 Using the JSON format:
@@ -137,7 +137,7 @@ Using the JSON format:
 ```shell
 $ wp vuln status --format=json
 
-{"core":[{"name":"WordPress","installed version":"6.2.2","status":"No vulnerabilities reported for this version of WordPress","introduced in":"n\/a","fixed in":"n\/a"}],"plugins":[{"name":"simple-podcasting","installed version":"1.3.0","status":"No vulnerabilities reported for this version of simple-podcasting","introduced in":"n\/a","fixed in":"n\/a"},{"name":"woocommerce","installed version":"7.8.2","status":"No vulnerabilities reported for this version of woocommerce","introduced in":"n\/a","fixed in":"n\/a"},{"name":"wordpress-seo","installed version":"20.2","status":"Wordpress Yoast SEO plugin <= 20.2 - Authenticated (Contributor+) DOM-Based Cross-Site Scripting vulnerability","introduced in":"<= 20.2","fixed in":"20.2.1"}],"themes":[{"name":"twentytwentythree","installed version":"1.1","status":"No vulnerabilities reported for this version of twentytwentythree","introduced in":"n\/a","fixed in":"n\/a"}]}
+{"core":[{"name":"WordPress","installed version":"6.2.2","status":"No vulnerabilities reported for this version of WordPress","introduced in":"n\/a","fixed in":"n\/a","severity":"n\/a"}],"plugins":[{"name":"simple-podcasting","installed version":"1.5.0","status":"No vulnerabilities reported for this version of simple-podcasting","introduced in":"n\/a","fixed in":"n\/a","severity":"n\/a"},{"name":"woocommerce","installed version":"7.8.2","status":"No vulnerabilities reported for this version of woocommerce","introduced in":"n\/a","fixed in":"n\/a","severity":"n\/a"},{"name":"wordpress-seo","installed version":"20.2","status":"Wordpress Yoast SEO plugin <= 20.2 - Authenticated (Contributor+) DOM-Based Cross-Site Scripting vulnerability","introduced in":"<= 20.2","fixed in":"20.2.1","severity":"Medium 6.5\/10"}],"themes":[{"name":"twentytwentythree","installed version":"1.1","status":"No vulnerabilities reported for this version of twentytwentythree","introduced in":"n\/a","fixed in":"n\/a","severity":"n\/a"}]}
 ```
 
 #### Checking any given theme:
@@ -145,11 +145,12 @@ $ wp vuln status --format=json
 ```shell
 $ wp vuln theme-check twentyfifteen --version=1.1
 
-+------------------------+-------------------+--------------------------------------------------------------+----------+
-| name                   | installed version | status                                                       | fixed in |
-+------------------------+-------------------+--------------------------------------------------------------+----------+
-| twentyfifteen          | 1.1               | Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS) | 1.2      |
-+------------------------+-------------------+--------------------------------------------------------------+----------+
+Vulnerability API Provider: Patchstack
++---------------+-------------------+--------------------------------------------------------------+----------+----------+
+| name          | installed version | status                                                       | fixed in | severity |
++---------------+-------------------+--------------------------------------------------------------+----------+----------+
+| twentyfifteen | 1.1               | WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting | 1.2      | n/a      |
++---------------+-------------------+--------------------------------------------------------------+----------+----------+
 ```
 
 Using the JSON format:
@@ -157,7 +158,7 @@ Using the JSON format:
 ```shell
 $ wp vuln theme-check twentyfifteen --version=1.1 --format=json
 
-[{"name":"twentyfifteen","installed version":"1.1","status":"Twenty Fifteen Theme <= 1.1 - DOM Cross-Site Scripting (XSS)","fixed in":"1.2"}]
+[{"name":"twentyfifteen","installed version":"1.1","status":"WordPress Twenty Fifteen Theme <= 1.1 - Cross Site Scripting","fixed in":"1.2","severity":"n\/a"}]
 ```
 
 ### Example usage


### PR DESCRIPTION
### Description of the Change
PR adds severity data of vulnerability in command output.

![image](https://user-images.githubusercontent.com/10613171/229153629-86180a80-3fe9-45bb-9a1a-197c8cff0cdb.png)


Closes #85 

### How to test the Change
1. Configure this scanner repo and configure API provider
2. Run commands like `wp vuln status`, `wp vuln theme-status` etc... and make sure severity details are there.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Vulnerability severity data to command output.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
