### PR TITLE
update Wordfence Intelligence references

### DIFF
--- a/includes/class-vulnerability-cli.php
+++ b/includes/class-vulnerability-cli.php
@@ -732,7 +732,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$api_providers = array(
 			'wpscan'     => 'WPScan',
 			'patchstack' => 'Patchstack',
-			'wordfence'  => 'Wordfence Intelligence CE',
+			'wordfence'  => 'Wordfence Intelligence',
 		);
 
 		$api_provider = $api_providers['wpscan'];

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ wp package install 10up/wpcli-vulnerability-scanner:dev-trunk
 ```
 
 ### API Access
-WP-CLI Vulnerability Scanner works with [WPScan](https://wpscan.com), [Patchstack](https://patchstack.com/) and [Wordfence Intelligence CE](https://www.wordfence.com/threat-intel/) to check reported vulnerabilities; you can choose any one of these three to use. You will need to add a constant in your `wp-config.php` to decide which API service you want to use (by default **WPScan API** will be used). 
+WP-CLI Vulnerability Scanner works with [WPScan](https://wpscan.com), [Patchstack](https://patchstack.com/) and [Wordfence Intelligence](https://www.wordfence.com/threat-intel/) to check reported vulnerabilities; you can choose any one of these three to use. You will need to add a constant in your `wp-config.php` to decide which API service you want to use (by default **WPScan API** will be used). 
 
 To use **WPScan API**:
 ```
@@ -27,7 +27,7 @@ To use **Patchstack API**:
 define( 'VULN_API_PROVIDER', 'patchstack' );
 ```
 
-To use **Wordfence Intelligence CE API**:
+To use **Wordfence Intelligence API**:
 ```
 define( 'VULN_API_PROVIDER', 'wordfence' );
 ```
@@ -175,7 +175,7 @@ export VULN_API_PROVIDER='patchstack'
 export VULN_API_TOKEN='Your API Token Here'
 ```
 
-To run tests against **Wordfence Intelligence CE API**, VULN_API_TOKEN is not required:
+To run tests against **Wordfence Intelligence API**, VULN_API_TOKEN is not required:
 
 ```
 export VULN_API_PROVIDER='wordfence'

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ To use **Wordfence Intelligence API**:
 ```
 define( 'VULN_API_PROVIDER', 'wordfence' );
 ```
-***Note**: Authentication is not required for the Wordfence Intelligence Community Edition API ( https://www.wordfence.com/wti-community-edition-terms-and-conditions/ ). VULN_API_TOKEN is not required if using Wordfence as your provider.*
+***Note**: Authentication is not required for the Wordfence Intelligence Vulnerability API ( https://www.wordfence.com/wti-community-edition-terms-and-conditions/ ). VULN_API_TOKEN is not required if using Wordfence as your provider.*
 
 For WPScan and Patchstack you will need to register for a user account and supply an API token from the chosen API service. Once you have acquired the token, you can add it as a constant in wp-config.php as follows:
 


### PR DESCRIPTION
Wordfence asked that we remove the "CE" references to make their branding appear primarily as either Wordfence Intelligence or Wordfence Intelligence Vulnerability API.