### PR TITLE
Added vulnerability reference link information.

### DIFF
--- a/features/vuln-patchstack.feature
+++ b/features/vuln-patchstack.feature
@@ -103,3 +103,8 @@ Feature: Test WP-CLI Features with Patchstack API.
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be empty
+
+  Scenario: Should show reference information on request (wp vuln core-status --reference)
+    When I run `wp vuln core-status --reference`
+    Then STDOUT should end with a table containing rows:
+      | name | installed version | status | introduced in | fixed in | reference |

--- a/features/vuln-wordfence.feature
+++ b/features/vuln-wordfence.feature
@@ -103,3 +103,8 @@ Feature: Test WP-CLI Features with Wordfence API.
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be empty
+
+  Scenario: Should show reference information on request (wp vuln core-status --reference)
+    When I run `wp vuln core-status --reference`
+    Then STDOUT should end with a table containing rows:
+      | name | installed version | status | introduced in | fixed in | reference |

--- a/features/vuln-wpscan.feature
+++ b/features/vuln-wpscan.feature
@@ -103,3 +103,8 @@ Feature: Test WP-CLI Features with WPScan API.
 
     When I run `wp vuln theme-status --porcelain`
     Then STDOUT should be empty
+
+  Scenario: Should show reference information on request (wp vuln core-status --reference)
+    When I run `wp vuln core-status --reference`
+    Then STDOUT should end with a table containing rows:
+      | name | installed version | status | introduced in | fixed in | reference |

--- a/includes/class-vuln-patchstack-service.php
+++ b/includes/class-vuln-patchstack-service.php
@@ -225,6 +225,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 					'action'      => '',
 					'fixed in'    => 'n/a',
 					'affected_in' => 'n/a',
+					'reference'   => 'n/a',
 				)
 			);
 
@@ -256,6 +257,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 				'status'            => $stat['title'],
 				'fixed in'          => $stat['fixed in'],
 				'introduced in'     => $stat['affected_in'],
+				'reference'         => $stat['reference'],
 				'action'            => $stat['action'],
 			);
 
@@ -329,6 +331,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 								'action'      => '',
 								'fixed in'    => 'n/a',
 								'affected_in' => 'n/a',
+								'reference'   => 'n/a',
 							)
 						);
 
@@ -356,6 +359,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 							'status'            => $stat['title'],
 							'fixed in'          => $stat['fixed in'],
 							'introduced in'     => $stat['affected_in'],
+							'reference'         => $stat['reference'],
 							'action'            => $stat['action'],
 						);
 
@@ -386,6 +390,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 			$affected_in = $this->obj_has_non_empty_prop( 'affected_in', $vuln );
 			// Check for fix version.
 			$fixed_since = $this->obj_has_non_empty_prop( 'fixed_in', $vuln );
+			$reference   = $this->obj_has_non_empty_prop( 'direct_url', $vuln );
 
 			// vulnerability that hasn't been fixed :(.
 			if ( ! $fixed_since ) {
@@ -395,6 +400,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 					'title'       => $vuln->title,
 					'fixed in'    => 'Not fixed',
 					'affected_in' => $affected_in ? $vuln->affected_in : 'n/a',
+					'reference'   => $reference ? $vuln->direct_url : 'n/a',
 					'action'      => 'watch',
 				);
 
@@ -406,6 +412,7 @@ class Vuln_Patchstack_Service extends Vuln_Service {
 					'title'       => $vuln->title,
 					'fixed in'    => $vuln->fixed_in,
 					'affected_in' => $affected_in ? $vuln->affected_in : 'n/a',
+					'reference'   => $reference ? $vuln->direct_url : 'n/a',
 					'action'      => 'update',
 				);
 			}

--- a/includes/class-vuln-wordfence-service.php
+++ b/includes/class-vuln-wordfence-service.php
@@ -190,7 +190,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 						'action'      => '',
 						'fixed in'    => 'n/a',
 						'affected_in' => 'n/a',
-						'reference'   => '',
+						'reference'   => 'n/a',
 						'copyrights'  => '',
 					)
 				);
@@ -274,7 +274,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					'fixed in'    => 'Not fixed',
 					'affected_in' => 'n/a',
 					'action'      => 'watch',
-					'reference'   => $vuln->references ? $vuln->references[0] : '',
+					'reference'   => $vuln->references ? $vuln->references[0] : 'n/a',
 					'copyrights'  => $vuln->copyrights ? (array) $vuln->copyrights : array(),
 				);
 
@@ -286,7 +286,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					'fixed in'    => $fixed_version,
 					'affected_in' => 'n/a',
 					'action'      => 'update',
-					'reference'   => $vuln->references ? $vuln->references[0] : '',
+					'reference'   => $vuln->references ? $vuln->references[0] : 'n/a',
 					'copyrights'  => $vuln->copyrights ? (array) $vuln->copyrights : array(),
 				);
 			}

--- a/includes/class-vuln-wordfence-service.php
+++ b/includes/class-vuln-wordfence-service.php
@@ -190,6 +190,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 						'action'      => '',
 						'fixed in'    => 'n/a',
 						'affected_in' => 'n/a',
+						'reference'   => '',
 						'copyrights'  => '',
 					)
 				);
@@ -223,6 +224,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					'fixed in'          => $stat['fixed in'],
 					'introduced in'     => $stat['affected_in'],
 					'action'            => $stat['action'],
+					'reference'         => $stat['reference'],
 					'copyrights'        => $stat['copyrights'],
 				);
 
@@ -272,6 +274,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					'fixed in'    => 'Not fixed',
 					'affected_in' => 'n/a',
 					'action'      => 'watch',
+					'reference'   => $vuln->references ? $vuln->references[0] : '',
 					'copyrights'  => $vuln->copyrights ? (array) $vuln->copyrights : array(),
 				);
 
@@ -283,6 +286,7 @@ class Vuln_Wordfence_Service extends Vuln_Service {
 					'fixed in'    => $fixed_version,
 					'affected_in' => 'n/a',
 					'action'      => 'update',
+					'reference'   => $vuln->references ? $vuln->references[0] : '',
 					'copyrights'  => $vuln->copyrights ? (array) $vuln->copyrights : array(),
 				);
 			}

--- a/includes/class-vuln-wpscan-service.php
+++ b/includes/class-vuln-wpscan-service.php
@@ -94,6 +94,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 								'title'         => $vuln->title,
 								'fixed in'      => 'Not fixed',
 								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
+								'reference'     => 'https://wpscan.com/vulnerability/' . $vuln->id,
 								'action'        => 'watch',
 							);
 
@@ -120,6 +121,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 								'title'         => $vuln->title,
 								'fixed in'      => $vuln->fixed_in,
 								'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
+								'reference'     => 'https://wpscan.com/vulnerability/' . $vuln->id,
 								'action'        => 'update',
 							);
 
@@ -154,6 +156,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 					'action'        => '',
 					'fixed in'      => 'n/a',
 					'introduced_in' => 'n/a',
+					'reference'     => 'n/a',
 				)
 			);
 
@@ -181,6 +184,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 				'status'            => $stat['title'],
 				'fixed in'          => $stat['fixed in'],
 				'introduced in'     => $stat['introduced_in'],
+				'reference'         => $stat['reference'],
 				'action'            => $stat['action'],
 			);
 		}
@@ -256,6 +260,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 							'title'         => $vuln->title,
 							'fixed in'      => 'Not fixed',
 							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
+							'reference'     => 'https://wpscan.com/vulnerability/' . $vuln->id,
 							'action'        => 'watch',
 						);
 
@@ -282,6 +287,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 							'title'         => $vuln->title,
 							'fixed in'      => $vuln->fixed_in,
 							'introduced_in' => $reported_since ? $vuln->introduced_in : 'n/a',
+							'reference'     => 'https://wpscan.com/vulnerability/' . $vuln->id,
 							'action'        => 'update',
 						);
 
@@ -316,6 +322,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 					'action'        => '',
 					'fixed in'      => 'n/a',
 					'introduced_in' => 'n/a',
+					'reference'     => 'n/a',
 				)
 			);
 			$name = ( $table_format && $slug === $last_item ? '' : $slug );
@@ -342,6 +349,7 @@ class Vuln_WPScan_Service extends Vuln_Service {
 				'status'            => $stat['title'],
 				'fixed in'          => $stat['fixed in'],
 				'introduced in'     => $stat['introduced_in'],
+				'reference'         => $stat['reference'],
 				'action'            => $stat['action'],
 			);
 			$last_item = $slug;

--- a/includes/class-vulnerability-cli.php
+++ b/includes/class-vulnerability-cli.php
@@ -49,6 +49,11 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	private $mail;
 
 	/**
+	 * Flag for reference
+	 */
+	private $reference;
+
+	/**
 	 * Vulnerability Scanner API Service
 	 *
 	 * @var object
@@ -75,6 +80,9 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 *
 	 * [--mail]
 	 * : Mail nagios output if any vulnerability found
+	 * 
+	 * [--reference]
+	 * : Add vulnerability reference link to the output 	
 	 *
 	 * [--format=<format>]
 	 * : Accepted values: table, csv, json, count, ids, yaml. Default: table
@@ -94,6 +102,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$this->test      = isset( $assoc_args['test'] );
 
 		$this->nagios_op = isset( $assoc_args['nagios'] );
+		$this->reference = isset( $assoc_args['reference'] );
 		$this->mail      = isset( $assoc_args['mail'] ) ? $assoc_args['mail'] : '';
 
 		$this->update_list = array();
@@ -145,6 +154,9 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 * [--mail]
 	 * : Mail nagios output if any vulnerability found
 	 *
+	 * [--reference]
+	 * : Add vulnerability reference link to the output
+	 *
 	 * [--format=<format>]
 	 * : Accepted values: table, csv, json, count, ids, yaml. Default: table
 	 *
@@ -162,6 +174,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$this->test      = isset( $assoc_args['test'] );
 
 		$this->nagios_op = isset( $assoc_args['nagios'] );
+		$this->reference = isset( $assoc_args['reference'] );
 		$this->mail      = isset( $assoc_args['mail'] ) ? $assoc_args['mail'] : '';
 
 		$this->update_list = array();
@@ -201,6 +214,9 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 * [--mail]
 	 * : Mail nagios output if any vulnerability found
 	 *
+	 * [--reference]
+	 * : Add vulnerability reference link to the output
+	 * 
 	 * [--format=<format>]
 	 * : Accepted values: table, csv, json, count, ids, yaml. Default: table
 	 *
@@ -218,6 +234,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$this->test      = isset( $assoc_args['test'] );
 
 		$this->nagios_op = isset( $assoc_args['nagios'] );
+		$this->reference = isset( $assoc_args['reference'] );
 		$this->mail      = isset( $assoc_args['mail'] ) ? $assoc_args['mail'] : '';
 
 		$this->update_list = array();
@@ -253,6 +270,9 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 * [--nagios]
 	 * : Output for nagios
 	 *
+	 * [--reference]
+	 * : Add vulnerability reference link to the output
+	 *
 	 * [--format=<format>]
 	 * : Accepted values: table, csv, json, count, ids, yaml. Default: table
 	 *
@@ -268,6 +288,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		$format          = isset( $assoc_args['format'] ) ? $assoc_args['format'] : 'table';
 		$this->porcelain = isset( $assoc_args['porcelain'] );
 		$this->test      = isset( $assoc_args['test'] );
+		$this->reference = isset( $assoc_args['reference'] );
 
 		$this->nagios_op = isset( $assoc_args['nagios'] );
 
@@ -302,6 +323,9 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 * [--version]
 	 * : Version if other than latest. Only applies if one slug provided
 	 *
+	 * [--reference]
+	 * : Add vulnerability reference link to the output
+	 *
 	 * [--format=<format>]
 	 * : Accepted values: table, csv, json, count, ids, yaml. Default: table
 	 *
@@ -312,7 +336,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 * @subcommand theme-check
 	 */
 	public function theme_check( $args, $assoc_args ) {
-
+		$this->reference = isset( $assoc_args['reference'] );
 		$this->init( $assoc_args );
 		if ( count( $args ) > 1 ) {
 			$version = 0;
@@ -364,6 +388,9 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 * [--version]
 	 * : Version if other than latest. Only applies if one slug provided
 	 *
+	 * [--reference]
+	 * : Add vulnerability reference link to the output
+	 *
 	 * [--format=<format>]
 	 * : Accepted values: table, csv, json, count, ids, yaml. Default: table
 	 *
@@ -374,7 +401,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 * @subcommand plugin-check
 	 */
 	public function plugin_check( $args, $assoc_args ) {
-
+		$this->reference = isset( $assoc_args['reference'] );
 		$this->init( $assoc_args );
 		if ( count( $args ) > 1 ) {
 			$version = 0;
@@ -455,27 +482,27 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 		// Pretty print.
 		if ( ! $this->porcelain ) {
+			$fields = array(
+				'name'              => true,
+				'installed version' => false,
+				'status'            => false,
+				'introduced in'     => false,
+				'fixed in'          => false,
+			);
+			if ( $this->reference ) {
+				$fields['reference'] = false;
+			}
+
 			$formatter = new \WP_CLI\Formatter(
 				$this->$assoc_args,
-				array(
-					'name',
-					'installed version',
-					'status',
-					'introduced in',
-					'fixed in',
-				),
+				array_keys( $fields ),
 				$plural_type
 			);
+
 			// Add second array parameter to indicate the position of the column having a maybe colorized item.
 			$formatter->display_items(
 				$display,
-				array(
-					true,
-					false,
-					false,
-					false,
-					false,
-				)
+				array_values( $fields )
 			);
 			// Improve readeability: force new line.
 			if ( 'ids' === $display_format ) {

--- a/includes/class-vulnerability-cli.php
+++ b/includes/class-vulnerability-cli.php
@@ -80,9 +80,9 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 *
 	 * [--mail]
 	 * : Mail nagios output if any vulnerability found
-	 * 
+	 *
 	 * [--reference]
-	 * : Add vulnerability reference link to the output 	
+	 * : Add vulnerability reference link to the output
 	 *
 	 * [--format=<format>]
 	 * : Accepted values: table, csv, json, count, ids, yaml. Default: table
@@ -216,7 +216,7 @@ class Vulnerability_CLI extends WP_CLI_Command {
 	 *
 	 * [--reference]
 	 * : Add vulnerability reference link to the output
-	 * 
+	 *
 	 * [--format=<format>]
 	 * : Accepted values: table, csv, json, count, ids, yaml. Default: table
 	 *
@@ -426,7 +426,6 @@ class Vulnerability_CLI extends WP_CLI_Command {
 
 		// Collect copyrights data.
 		$this->collect_copyrights_data( $display );
-
 
 		$fields = array(
 			'name'              => true,

--- a/includes/class-vulnerability-cli.php
+++ b/includes/class-vulnerability-cli.php
@@ -355,21 +355,28 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		// Collect copyrights data.
 		$this->collect_copyrights_data( $display );
 
+		$fields = array(
+			'name'              => true,
+			'installed version' => false,
+			'status'            => false,
+			'fixed in'          => false,
+		);
+		if ( $this->reference ) {
+			$fields['reference'] = false;
+		}
+
 		$formatter = new \WP_CLI\Formatter(
 			$assoc_args,
-			array(
-				'name',
-				'installed version',
-				'status',
-				'fixed in',
-			),
+			array_keys( $fields ),
 			'themes'
 		);
 
 		if ( 'table' === $format ) {
 			WP_CLI::log( $this->get_api_provider_credit() );
 		}
-		$formatter->display_items( $display );
+
+		// Add second array parameter to indicate the position of the column having a maybe colorized item.
+		$formatter->display_items( $display, array_values( $fields ) );
 
 		// Display the copyright notice.
 		if ( ! $this->porcelain && 'table' === $format && ! empty( $this->get_copyright_notice() ) ) {
@@ -420,21 +427,29 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		// Collect copyrights data.
 		$this->collect_copyrights_data( $display );
 
+
+		$fields = array(
+			'name'              => true,
+			'installed version' => false,
+			'status'            => false,
+			'fixed in'          => false,
+		);
+		if ( $this->reference ) {
+			$fields['reference'] = false;
+		}
+
 		$formatter = new \WP_CLI\Formatter(
 			$assoc_args,
-			array(
-				'name',
-				'installed version',
-				'status',
-				'fixed in',
-			),
+			array_keys( $fields ),
 			'plugins'
 		);
 
 		if ( 'table' === $format ) {
 			WP_CLI::log( $this->get_api_provider_credit() );
 		}
-		$formatter->display_items( $display );
+
+		// Add second array parameter to indicate the position of the column having a maybe colorized item.
+		$formatter->display_items( $display, array_values( $fields ) );
 
 		// Display the copyright notice.
 		if ( ! $this->porcelain && 'table' === $format && ! empty( $this->get_copyright_notice() ) ) {
@@ -559,27 +574,27 @@ class Vulnerability_CLI extends WP_CLI_Command {
 		// Pretty print.
 		if ( ! $this->porcelain ) {
 
+			$fields = array(
+				'name'              => true,
+				'installed version' => false,
+				'status'            => false,
+				'introduced in'     => false,
+				'fixed in'          => false,
+			);
+			if ( $this->reference ) {
+				$fields['reference'] = false;
+			}
+
 			$formatter = new \WP_CLI\Formatter(
 				$this->$assoc_args,
-				array(
-					'name',
-					'installed version',
-					'status',
-					'introduced in',
-					'fixed in',
-				),
+				array_keys( $fields ),
 				$plural_type
 			);
+
 			// Add second array parameter to indicate the position of the column having a maybe colorized item.
 			$formatter->display_items(
 				$display,
-				array(
-					true,
-					false,
-					false,
-					false,
-					false,
-				)
+				array_values( $fields )
 			);
 
 			// if plugins need updating, do or tell the user.

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,8 @@ wp vuln status
  * `--test` Load test data
  * `--format=<format>` Accepted values: table, csv, json, count, ids, yaml. Default: table
  * `--nagios` Output for nagios
- 
+ * `--reference` includes the reference link of the vulnerability within the output
+
 ```
 wp vuln core-status
 ```
@@ -77,6 +78,7 @@ wp vuln core-status
  * *Options:*
  * `--format=<format>` Accepted values: table, csv, json, count, ids, yaml. Default: table
  * `--nagios` Output for nagios
+ * `--reference` includes the reference link of the vulnerability within the output
 
 ```
 wp vuln plugin-status
@@ -87,6 +89,7 @@ wp vuln plugin-status
  * `--porcelain` Only print slugs of vulnerable plugins with updates
  * `--format=<format>` Accepted values: table, csv, json, count, ids, yaml. Default: table
  * `--nagios` Output for nagios
+ * `--reference` includes the reference link of the vulnerability within the output
  
 ```
 wp vuln theme-status
@@ -97,6 +100,7 @@ wp vuln theme-status
  * `--porcelain` Only print slugs of vulnerable theme with updates
  * `--format=<format>` Accepted values: table, csv, json, count, ids, yaml. Default: table
  * `--nagios` Output for nagios
+ * `--reference` includes the reference link of the vulnerability within the output
 
 ### Example usage
 


### PR DESCRIPTION
### Description of the Change
PR adds vulnerability reference link information to provide the functionality to users to view more details on vulnerability. Users can now get reference link along with other vulnerability information by adding `--reference` to the wp-cli vuln command. eg: `wp vuln plugin-status  --reference`

![image](https://github.com/10up/wpcli-vulnerability-scanner/assets/10613171/ecb7006f-e918-492f-9570-0bbbe1b8f71e)


Closes #84 

### How to test the Change
1. Configure this scanner repo and configure the API provider
2. Run vuln commands by adding the `--reference` flag and make sure that reference information is there. example:  `wp vuln status --reference`, `wp vuln theme-status --reference`
3. Try different formats like JSON and CSV and make sure that reference information is there. (add `--format=csv`)
4. Test with different API providers (Wordfence, WPScan, Patchstack) and verify that it works well with all providers.


### Changelog Entry
> Added - Vulnerability reference link information.


### Credits
Props @iamdharmesh @bmarshall511 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
