### PR TITLE
Enhance readme with API access and FAQ sections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ wp package install 10up/wpcli-vulnerability-scanner:dev-stable
 ```
 
 ### API Access
+
 WP-CLI Vulnerability Scanner works with [WPScan](https://wpscan.com), [Patchstack](https://patchstack.com/) and [Wordfence Intelligence](https://www.wordfence.com/threat-intel/) to check reported vulnerabilities; you can choose any one of these three to use. You will need to add a constant in your `wp-config.php` to decide which API service you want to use (by default **WPScan API** will be used).
 
 To use **WPScan API**:
@@ -38,7 +39,6 @@ For WPScan and Patchstack you will need to register for a user account and suppl
 ```
 define( 'VULN_API_TOKEN', 'YOUR_TOKEN_HERE' );
 ```
-
 
 ### Global command, manually
 
@@ -267,6 +267,12 @@ composer behat -- features/vuln-patchstack.feature
 ```
 composer behat -- features/vuln-wordfence.feature
 ```
+
+## Frequently Asked Questions
+
+### Where do I report security bugs found in this plugin?
+
+Please report security bugs found in the source code of the undefined plugin through the [Patchstack Vulnerability Disclosure  Program](https://patchstack.com/database/vdp/189e9e72-27f1-4d80-86fd-7a28975550af).  The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
 
 ## Support Level
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates the `readme.md` documentation for the WP-CLI Vulnerability Scanner plugin. The main changes clarify API options and add a new FAQ section for security reporting.

Documentation improvements:

* Clarified that users can choose between WPScan, Patchstack, and Wordfence Intelligence APIs, and explained how to configure the API service in `wp-config.php`.
* Improved section formatting for the global command instructions.

Security and support information:

* Added a new "Frequently Asked Questions" section, including instructions on how to report security bugs via the Patchstack Vulnerability Disclosure Program.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Add Patchstack security-reporting FAQ.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
